### PR TITLE
Add a server parameter config option for number of workers/threads

### DIFF
--- a/psiturk/experiment_server.py
+++ b/psiturk/experiment_server.py
@@ -42,10 +42,14 @@ class ExperimentServer(Application):
         return util.import_app("experiment:app")
 
     def load_user_config(self):
+        workers = config.get("Server Parameters", "num_workers")
+        if workers == "-1":
+            workers = str(multiprocessing.cpu_count() * 2 + 1)
+
         self.loglevels = ["debug", "info", "warning", "error", "critical"]
         self.user_options = {
             'bind': config.get("Server Parameters", "host") + ":" + config.get("Server Parameters", "port"),
-            'workers': str(multiprocessing.cpu_count() * 2 + 1),
+            'workers': workers,
             'loglevels': self.loglevels,
             'loglevel': self.loglevels[config.getint("Server Parameters", "loglevel")]
         }

--- a/psiturk/psiturk_config.py
+++ b/psiturk/psiturk_config.py
@@ -77,6 +77,7 @@ class PsiturkConfig(SafeConfigParser):
         self.set('Server Parameters', 'debug', 'true')
         self.set('Server Parameters', 'login_username', 'examplename')
         self.set('Server Parameters', 'login_pw', 'examplepassword')
+        self.set('Server Parameters', 'num_workers', '-1')
         
         # Task Parameters
         self.set('Task Parameters', 'code_version', '1.0')


### PR DESCRIPTION
The server that I'm running the experiment server from will kill my processes if they are using too much memory/CPU, which I find is the case if PsiTurk launches `2n-1` processes. This pull request adds a new server parameter, `num_workers`, which defaults to using `2n-1` processes but can be changed to specify exactly how many processes to use if you want.

I'm not sure if there was any other place that I should update to account for a new parameter -- let me know if I missed something, and I'll update the pull request.
