### PR TITLE
Dashboard authentication

### DIFF
--- a/psiturk/psiturk_config.py
+++ b/psiturk/psiturk_config.py
@@ -45,7 +45,8 @@ class PsiturkConfig(SafeConfigParser):
 
     def write_default_config(self):
         sections = ['AWS Access', 'HIT Configuration', 'Database Parameters',
-                    'Server Parameters', 'Task Parameters']
+                    'Server Parameters', 'Task Parameters',
+                    'Dashboard Parameters']
         map(self.add_section, sections)
         # AWS Access Section
         self.set('AWS Access', 'aws_access_key_id', 'YourAccessKeyId')
@@ -84,3 +85,7 @@ class PsiturkConfig(SafeConfigParser):
         self.set('Task Parameters', 'num_conds', '1')
         self.set('Task Parameters', 'num_counters', '1')
         self.set('Task Parameters', 'use_debriefing', 'true')
+
+        # Dashboard Parameters
+        self.set('Dashboard Parameters', 'login_username', '')
+        self.set('Dashboard Parameters', 'login_pw', '')


### PR DESCRIPTION
I'm opening a pull request just to keep track of progress for dashboard authentication; when it's merged it should fix #21.
- As a start, I've added a new configuration section (`Dashboard Parameters`) with configuration options `login_username` and `login_pw`. Both options default to empty strings. 
- Then, in `dashboard_server.py`, I added functions to handle authentication (mostly taken from Jay's tip about http://flask.pocoo.org/snippets/8/ ) and decorated all the routes to require authentication.
- I added in behavior to not require authentication if either the username or password is blank -- the idea being that if someone wants to turn on auth, they should provide both a username and password.
- I briefly tested this on Chrome and it appears to work, but it should probably be tested a little more rigorously and on other browsers. 
- Also, the dashboard itself needs an interface to modify the username/password. I don't know coffeescript, though, and I'm not sure where the best place to add it would be -- create a new sidebar tab for dashboard configuration? Add it to the existing dashboard tab? Add it under server configuration?
