### PR TITLE
Add separate route to fetch taskdata

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -458,7 +458,7 @@ def update(uid=None):
     except:
         app.logger.error( "DB error: Unique user not found.")
 
-    if hasattr(request, 'data'):
+    if hasattr(request, 'json'):
         user.datastring = request.data.decode('utf-8').encode('ascii', 'xmlcharrefreplace')
         db_session.add(user)
         db_session.commit()


### PR DESCRIPTION
Backbone models can both save and fetch data, but currently the `sync` route only really supports saving data -- at least, currently, it just returns data corresponding to stuff like the id and condition, but doesn't return anything for `data`, `questiondata`, or `eventdata`. This means that on the JavaScript side, those values just get set to the defaults. However, it seems like it would be better if these values were populated from the database if they already exist there. This has the added benefit of allowing people to refresh the page, and still have their state stored (assuming the JavaScript itself can handle restarting from a given state).

This might be a change that is more appropriate for 2.1.0, so let me know if I should resubmit this pull request to `dev`.
