### PR TITLE
throw error when page is loaded without preloading

### DIFF
--- a/psiturk/psiturk_js/psiturk.js
+++ b/psiturk/psiturk_js/psiturk.js
@@ -204,7 +204,7 @@ var PsiTurk = function(uniqueId, adServerLoc) {
 	self.getPage = function(pagename) {
 		if (!(pagename in self.pages)){
 		    throw new Error(
-			["Attemping to load page before preloading: ",
+			["Attempting to load page before preloading: ",
 			pagename].join(""));
 		};
 		return self.pages[pagename];


### PR DESCRIPTION
Rather than fail silently, this makes it easier to see what page you forgot to add to the preloadPages call.
