### PR TITLE
throw error when page is loaded without preloading

### DIFF
--- a/psiturk/psiturk_js/psiturk.js
+++ b/psiturk/psiturk_js/psiturk.js
@@ -202,6 +202,11 @@ var PsiTurk = function(uniqueId, adServerLoc) {
 	};
 	// Get HTML file from collection and pass on to a callback
 	self.getPage = function(pagename) {
+		if (!(pagename in self.pages)){
+		    throw new Error(
+			["Attemping to load page before preloading: ",
+			pagename].join(""));
+		};
 		return self.pages[pagename];
 	};
 	


### PR DESCRIPTION
Lets you see what you forgot to preload instead of failing silently.
