### PR TITLE
Fix malformed HTML

### DIFF
--- a/psiturk/example/templates/ad.html
+++ b/psiturk/example/templates/ad.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!-- 
 	The ad.html has a very specific format.
 
@@ -19,9 +19,10 @@
 -->
 <html>
 	<head>
+                <meta charset="utf-8" />
 		<title>Psychology Experiment</title>
-		<link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
-		<style>
+		<link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
+		<style type="text/css">
 			/* these tyles need to be defined locally */
 			body {
 			    padding:0px;
@@ -112,7 +113,7 @@
 							    	By clicking the following URL link, you will be taken to the experiment,
 							        including complete instructions and an informed consent agreement.
 							    </p>
-							    <script>
+							    <script type="text/javascript">
 									function openwindow() {
 							    		popup = window.open('{{ server_location }}/consent?hitId={{ hitid }}&assignmentId={{ assignmentid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
 							  		}
@@ -131,7 +132,8 @@
 								endif
 							-->
 					</div>
-			</div>
+			        </div>
+		        </div>
 		</div>
 	</body>
 </html>

--- a/psiturk/example/templates/complete.html
+++ b/psiturk/example/templates/complete.html
@@ -1,10 +1,11 @@
-<!doctype html>
+<!DOCTYPE html>
 
 <html>
 	<head>
+                <meta charset="utf-8" />
 		<title>Psychology Experiment</title>
-		<link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
-		<link rel=stylesheet href="/static/css/style.css" type="text/css">
+		<link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
+		<link rel="stylesheet" href="/static/css/style.css" type="text/css" />
 	</head>
 	<body>
 		<div id="container-ad">
@@ -17,11 +18,12 @@
 					</div>
 					<div class="col-xs-10">
 						<h1>Debugging task complete!</h1>
-						<hr>
+						<hr />
 					    <div class="alert alert-warning">
 					    	If this was a real hit, the data would be saved now and the HIT submitted to AMT.
 					    </div>
 					</div>
+                                </div>
 			</div>
 		</div>
 	</body>

--- a/psiturk/example/templates/consent.html
+++ b/psiturk/example/templates/consent.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!-- 
   The consent.html displays the text of your IRB-approved
   consent form.  Even if you are not required to provide
@@ -8,9 +8,10 @@
 -->
 <html>
     <head>
+        <meta charset="utf-8" />
         <title>Psychology Experiment - Informed Consent Form</title>
-        <link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
-        <link rel=stylesheet href="/static/css/style.css" type="text/css">
+        <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
+        <link rel="stylesheet" href="/static/css/style.css" type="text/css" />
         <script type="text/javascript">
             function onexit() {
               self.close(); // no harm, no foul here
@@ -21,7 +22,7 @@
         <div id="container-consent">
             <div id="consent">
                 <h1>We need your consent to proceed</h1>
-                <hr>
+                <hr />
                 <div class="legal well">
                     <p>
                     You have been invited to take part in a research study named BLAH BLAH
@@ -36,9 +37,9 @@
                     </button>
                 </div>
 
-                <hr>
+                <hr />
                 <h4>Do you understand and consent to these terms?</h4>
-                <br>
+                <br />
 
                 <center>
                     <button type="button" class="btn btn-primary btn-lg" onClick="window.location='/exp?hitId={{ hitid }}&assignmentId={{ assignmentid }}&workerId={{ workerid }}'">

--- a/psiturk/example/templates/custom.html
+++ b/psiturk/example/templates/custom.html
@@ -1,10 +1,11 @@
-<!doctype html>
+<!DOCTYPE html>
 
 <html>
 <head>
+        <meta charset="utf-8" />
 	<title>Custom Routes</title>
-	<link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
-	<link rel=stylesheet href="/static/css/style.css" type="text/css" media="screen">
+	<link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
+	<link rel="stylesheet" href="/static/css/style.css" type="text/css" media="screen" />
 </head>
 <body>
 	<div style="text-align: center;" id="thanks">

--- a/psiturk/example/templates/debriefing.html
+++ b/psiturk/example/templates/debriefing.html
@@ -1,10 +1,11 @@
-<!doctype html>
+<!DOCTYPE html>
 
 
 <html>
 <head>
+        <meta charset="utf-8" />
 	<title>Debriefing</title>
-	<link rel="stylesheet" href="/static/css/task.css" type="text/css" media="screen">
+	<link rel="stylesheet" href="/static/css/task.css" type="text/css" media="screen" />
 </head>
 <body>
 	<div id="debriefing">
@@ -30,7 +31,7 @@
 		est notare quam littera gothica, quam nunc putamus parum claram,
 		anteposuerit litterarum formas humanitatis per seacula quarta decima et
 		quinta decima. Eodem modo typi, qui nunc nobis videntur parum clari, fiant
-		sollemnes in futurum.
+		sollemnes in futurum.</p>
 		
 		<p>If you have any questions about this research, you may contact the
 		principal investigator, Principal Investigator.</p>

--- a/psiturk/example/templates/default.html
+++ b/psiturk/example/templates/default.html
@@ -1,10 +1,11 @@
-<!doctype html>
+<!DOCTYPE html>
 
 <html>
 	<head>
+                <meta charset="utf-8" />
 		<title>Psychology Experiment</title>
-		<link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
-		<link rel=stylesheet href="/static/css/style.css" type="text/css">
+		<link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
+		<link rel="stylesheet" href="/static/css/style.css" type="text/css" />
 	</head>
 	<body>
 		<div id="container-ad">
@@ -17,11 +18,12 @@
 					</div>
 					<div class="col-xs-10">
 						<h1>Welcome to psiTurk!</h1>
-						<hr>
+						<hr />
 					    <div class="alert alert-warning">
 					    	Begin by viewing the <a href="/ad">ad</a>.
 					    </div>
 					</div>
+                                </div>
 			</div>
 		</div>
 	</body>

--- a/psiturk/example/templates/error.html
+++ b/psiturk/example/templates/error.html
@@ -1,16 +1,17 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8" />
         <title>Psychology Experiment - Error</title>
-        <link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
-        <link rel=stylesheet href="/static/css/style.css" type="text/css">
+        <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
+        <link rel="stylesheet" href="/static/css/style.css" type="text/css" />
     </head>
     <body>
         <div id="container-error">
 
             <div id="error">
                 <h1>Sorry, there was an error</h1>
-                <hr>
+                <hr />
 
                 <div class="alert alert-danger">
                 {% if errornum == 1008 %}
@@ -27,7 +28,7 @@
 
                 {% else %}
 
-                        <p>Sorry, there was an unexpected error in our processing of your HIT.<p>
+                        <p>Sorry, there was an unexpected error in our processing of your HIT.</p>
 
                 {% endif %}
                         <p>
@@ -37,15 +38,15 @@
                             and send the following information:
                         </p>
                         <p>
-                            Error: #{{ errornum }}<br>
-                            {% if hitId %} HITID: #{{ hitId }}<br> {% endif %}
-                            {% if assignId %}AssignmentId: #{{ assignId }}<br> {% endif %}
-                            {% if workerId %} WorkerId: #{{ workerId }}<br> {% endif %}
+                            Error: #{{ errornum }}<br />
+                            {% if hitId %} HITID: #{{ hitId }}<br /> {% endif %}
+                            {% if assignId %}AssignmentId: #{{ assignId }}<br /> {% endif %}
+                            {% if workerId %} WorkerId: #{{ workerId }}<br /> {% endif %}
                         </p>
 
                 </div>
 
-                <hr>
+                <hr />
                 <h3>Our sincere apologies!</h3>
             </div>
         </div>

--- a/psiturk/example/templates/exp.html
+++ b/psiturk/example/templates/exp.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <!-- 
   The exp.html is the main form that
   controls the experiment.
@@ -7,8 +7,8 @@
 -->
 <html>
     <head>
+        <meta charset="utf-8" />
         <title>Psychology Experiment</title>
-        <meta charset="utf-8">
         <link rel="Favicon" href="/static/favicon.ico" />
 
         <!-- libraries used in your experiment 
@@ -37,15 +37,15 @@
 		-->
 		<script src="/static/js/task.js" type="text/javascript"> </script>
 
-        <link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
-        <link rel=stylesheet href="/static/css/style.css" type="text/css">
+        <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
+        <link rel="stylesheet" href="/static/css/style.css" type="text/css" />
     </head>
     <body>
 	    <noscript>
 			<h1>Warning: Javascript seems to be disabled</h1>
 			<p>This website requires that Javascript be enabled on your browser.</p>
 			<p>Instructions for enabling Javascript in your browser can be found 
-			<a href="http://support.google.com/bin/answer.py?hl=en&answer=23852">here</a><p>
+			<a href="http://support.google.com/bin/answer.py?hl=en&answer=23852">here</a></p>
 		</noscript>
     </body>
 </html>

--- a/psiturk/example/templates/instructions/instruct-1.html
+++ b/psiturk/example/templates/instructions/instruct-1.html
@@ -2,7 +2,7 @@
 
 	<h1>Instructions</h1>
 
-	<hr>
+	<hr />
 
 	<div class="instructions well">
 
@@ -24,7 +24,7 @@
 
 	</div>
 
-	<hr>
+	<hr />
 
 
     <div class="instructionsnav">

--- a/psiturk/example/templates/instructions/instruct-2.html
+++ b/psiturk/example/templates/instructions/instruct-2.html
@@ -2,7 +2,7 @@
 
     <h1>Instructions</h1>
 
-    <hr>
+    <hr />
 
     <div class="instructions well">
 
@@ -21,7 +21,7 @@
 
     </div>
 
-    <hr>
+    <hr />
 
     <div class="instructionsnav">
         <div class="row">

--- a/psiturk/example/templates/instructions/instruct-3.html
+++ b/psiturk/example/templates/instructions/instruct-3.html
@@ -2,7 +2,7 @@
 
     <h1>Instructions</h1>
 
-    <hr>
+    <hr />
 
     <div class="instructions well">
 
@@ -21,7 +21,7 @@
 
     </div>
 
-    <hr>
+    <hr />
 
     <div class="instructionsnav">
         <div class="row">

--- a/psiturk/example/templates/instructions/instruct-ready.html
+++ b/psiturk/example/templates/instructions/instruct-ready.html
@@ -2,7 +2,7 @@
 
     <h1>Instructions</h1>
 
-    <hr>
+    <hr />
 
     <div class="instructions well">
 
@@ -21,7 +21,7 @@
 
     </div>
 
-    <hr>
+    <hr />
 
     <div class="instructionsnav">
         <div class="row">

--- a/psiturk/example/templates/list.html
+++ b/psiturk/example/templates/list.html
@@ -1,6 +1,6 @@
 <h1>Here are all your users in the database</h1>
 
 {% for person in participants: %}
-	{{ person.workerid }} &nbsp; {{ person.ipaddress }}<br>
+	{{ person.workerid }} &nbsp; {{ person.ipaddress }}<br />
 
 {% endfor %}

--- a/psiturk/example/templates/postquestionnaire.html
+++ b/psiturk/example/templates/postquestionnaire.html
@@ -1,7 +1,7 @@
 <div id="container-questionnaire">
     <h1>Task Complete</h1>
 
-    <hr>
+    <hr />
 
     <p>You are finished!  Thank you for your contributions to science. You will be eligible for full payment once you answer the following questions.</p>
 
@@ -59,7 +59,7 @@
         </form>
     </div>
 
-    <hr>
+    <hr />
 
     <div class="instructionsnav">
         <div class="row">

--- a/psiturk/example/templates/thanks.html
+++ b/psiturk/example/templates/thanks.html
@@ -1,10 +1,11 @@
-<!doctype html>
+<!DOCTYPE html>
 
 <html>
 	<head>
+                <meta charset="utf-8" />
 		<title>Psychology Experiment</title>
-		<link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
-		<link rel=stylesheet href="/static/css/style.css" type="text/css">
+		<link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
+		<link rel="stylesheet" href="/static/css/style.css" type="text/css" />
 	</head>
 	<body>
 		<div id="container-ad">
@@ -17,12 +18,13 @@
 					</div>
 					<div class="col-xs-10">
 						<h1>Thanks for your participation!</h1>
-						<hr>
+						<hr />
 					    <div class="alert alert-warning">
 					    	Our records suggest you have already completed this task.  Thank you.
 					    	You cannot complete the same experiment twice.
 					    </div>
 					</div>
+                                </div>
 			</div>
 		</div>
 	</body>


### PR DESCRIPTION
The HTML for the example experiment doesn't always quite conform to correct HTML syntax. This pull request just makes a few minor formatting changes, including:
- capitalizing DOCTYPE
- including a `<meta>` tag for the encoding (utf-8)
- closing various tags, like `<link />` and `<hr />` and `<br />`
- putting quotes around `stylesheet` in `<link rel="stylesheet" />`
- inserting a few missing closing tags
- specifying script and style types
