### PR TITLE
More unicode compatibility

### DIFF
--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -62,6 +62,8 @@ class MTurkHIT(object):
         self.options = json_options
 
     def __repr__(self):
+        for opt in self.options:
+            self.options[opt] = self.options[opt].encode('ascii', 'replace')
         return "%s \n\tStatus: %s \n\tHITid: %s \
             \n\tmax:%s/pending:%s/complete:%s/remain:%s \n\tCreated:%s \
             \n\tExpires:%s\n" % (

--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -636,6 +636,7 @@ def ppid():
 # to avoid breaking backwards compatibility with old templates.
 def insert_mode(page_html, mode):
     ''' Insert mode '''
+    page_html = page_html.decode("utf-8")
     match_found = False
     matches = re.finditer('workerId={{ workerid }}', page_html)
     match = None


### PR DESCRIPTION
(JSlote's) unicode compatibility for jinja templates in experiment.py.
Converts unicode that got into hit names into ascii, so can prit in CLI in aws_services.py.
