### PR TITLE
Read in requirements from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ gunicorn==18.0
 boto==2.15.0
 cmd2==0.6.7
 docopt==0.6.1
-gnureadline==6.3.3
 requests==2.2.1
 user-agents==0.2.0
 sh==1.09 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools import setup
 from psiturk.version import version_number
 
@@ -8,7 +9,6 @@ try:
         for line in readme_text:
             if line[0]!='<' and line[0]!='[': # drop lines that are html/markdown
                 long_description += line
-
 except IOError:
     long_description = ""
 
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     fp.flush()
     fp.close()
 
-    setup(
+    setup_args = dict(
         name = "PsiTurk",
         version = version_number,
         packages = ["psiturk"],
@@ -36,10 +36,6 @@ if __name__ == "__main__":
             ]
         },
         setup_requires = [],
-        install_requires = ["argparse", "Flask", "SQLAlchemy", "gunicorn",
-                            "boto>=2.9","cmd2","docopt","gnureadline","requests>=2.2.1","user_agents",
-                            "sh", "fake-factory", "gitpython", "fuzzywuzzy",
-                            "psutil>=1.2.1", "setproctitle"],
         author = "NYU Computation and Cognition Lab",
         author_email = "authors@psiturk.org",
         description = "An open platform for science on Amazon Mechanical Turk",
@@ -48,3 +44,18 @@ if __name__ == "__main__":
         test_suite='test_psiturk'
     )
 
+    # read in requirements.txt for dependencies
+    setup_args['install_requires'] = install_requires = []
+    with open('requirements.txt') as f:
+        for line in f.readlines():
+            req = line.strip()
+            if not req or req.startswith('#'): # ignore comments
+                continue
+            else:
+                install_requires.append(req)
+
+    # add readline only on osx
+    if sys.platform == 'darwin':
+        install_requires.append('gnureadline==6.3.3')
+
+    setup(**setup_args)


### PR DESCRIPTION
This pull request solves two problems:

1) `gnureadline` shouldn't need to be installed on linux systems, since the version of readline that they have is GNU by default.
2) Reduces code duplication by reading in the requirements from `requirements.txt` rather than having them separately in `requirements.txt` and `setup.py`.

The only downside is that then `gnureadline` isn't present at all in `requirements.txt`, but I think that should probably be ok, since that should only be a problem when you explicitly do `pip install -r requirements.txt`. If you install psiTurk from `pip` normally (i.e. `pip install psiturk`), or use `python setup.py install`, it will use the requirements in setup.py. An alternate strategy would be to keep `gnureadline` in `requirements.txt`, but remove it in `setup.py` if the system is linux. I'm happy to change it to do that if that's preferable.

Sigh, python packaging.
