### PR TITLE
Removed get_connections call for OpenShift

### DIFF
--- a/psiturk/experiment_server_controller.py
+++ b/psiturk/experiment_server_controller.py
@@ -139,12 +139,10 @@ class ExperimentServerController:
         cmd = "ps -eo pid,command | grep '"+ PROCNAME + "' | grep -v grep | awk '{print $1}'"
         psiturk_exp_processes = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         output = psiturk_exp_processes.stdout.readlines()
-        psiturk_exp_ports = []
-        if output:
-            psiturk_exp_ports = [process[0].laddr[1] for process in [psutil.Process(int(pid)).get_connections() for pid in output]]
         parent = psutil.Process(psiturk_exp_processes.pid)
         self.kill_child_processes(parent.pid)
-        if psiturk_exp_ports:
+        
+        if output:
             is_psiturk_using_port = True
         else:
             is_psiturk_using_port = False

--- a/psiturk/models.py
+++ b/psiturk/models.py
@@ -98,7 +98,7 @@ class Participant(Base):
     def get_question_data(self):
         try:
             questiondata = json.loads(self.datastring)["questiondata"]
-        except ValueError:
+        except (ValueError, TypeError):
             # There was no data to return.
             print("No question data found in record:", self)
             return("")

--- a/psiturk/models.py
+++ b/psiturk/models.py
@@ -78,7 +78,7 @@ class Participant(Base):
     def get_event_data(self):
         try:
             eventdata = json.loads(self.datastring)["eventdata"]
-        except ValueError:
+        except (ValueError, TypeError):
             # There was no data to return.
             print("No event data found in record:", self)
             return("")


### PR DESCRIPTION
This is an attempt to fix #155. psutils.Process().get_connections() fails on OpenShift as it does on many restrictive systems. Looks to me like the information gained from that was not being used anyways, just the result from the ps call above. Unless I'm missing somehting, the length of psiturk_exp_ports will be the same as that of output, and the test will pass simply by checking if output is true. So far, this seems to get OpenShift working for me again. 