### PR TITLE
remove superfluous code

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -75,12 +75,6 @@ except ImportError:
 else:
     app.register_blueprint(custom_code)
 
-try:
-    sys.path.append(os.getcwd())
-
-except ImportError:
-    app.logger.info("Hmm... it seems no custom model code (custom_models.py) \
-                    assocated with this project.")
 
 init_db()
 


### PR DESCRIPTION
Best as I can tell (I'm still gettting my bearings in psiturk's codebase so apologies if I'm wrong) this doesn't actually do anything. sys.path.append(os.getcwd()) doesn't throw ImportErrors and at least in your whoops y'all example the contents of custom_models.py are imported in custom.py, not in experiment.py