### PR TITLE
Better exception handling with custom.py

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -69,9 +69,15 @@ app.config.update(SEND_FILE_MAX_AGE_DEFAULT=10)
 try:
     sys.path.append(os.getcwd())
     from custom import custom_code
-except ImportError:
-    app.logger.info("Hmm... it seems no custom code (custom.py) assocated \
+except ImportError as e:
+    if str(e) == 'No module named custom':
+        app.logger.info("Hmm... it seems no custom code (custom.py) associated \
                     with this project.")
+        pass
+    else:
+        app.logger.error("There is custom code (custom.py) associated with this \
+                    project but it doesn't import cleanly. Raising exception,")
+        raise
 else:
     app.register_blueprint(custom_code)
 


### PR DESCRIPTION
Now catching only the ImportError that's caused by the absence of custom.py but re-raising all ImportErrors that are caused by screwed up imports _in_ custom.py and its dependencies.