### PR TITLE
cache control max age measured in seconds, not ms

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -59,7 +59,7 @@ BONUSED = 7
 # ===========
 
 app = Flask("Experiment_Server")
-# Set cache timeout to 10ms for static files
+# Set cache timeout to 10 seconds for static files
 app.config.update(SEND_FILE_MAX_AGE_DEFAULT=10)
 app.secret_key = CONFIG.get('Server Parameters', 'secret_key')
 app.logger.info("Secret key: " + app.secret_key)


### PR DESCRIPTION
see http://flask.pocoo.org/docs/0.10/config/

Also: Any reason the cache timeout shouldn't also be user configurable (perhaps with a sensible default)?