### PR TITLE
setup.py adds sample .psiturkconfig to user's home directory

### DIFF
--- a/psiturk/default_configs/.psiturkconfig
+++ b/psiturk/default_configs/.psiturkconfig
@@ -1,0 +1,8 @@
+[AWS Access]
+aws_access_key_id = YourAccessKeyId
+aws_secret_access_key = YourSecretAccessKey
+aws_region = us-east-1
+
+[psiTurk Access]
+psiturk_access_key_id = YourAccessKeyId
+psiturk_secret_access_id = YourSecretAccessKey

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
         description = "An open platform for science on Amazon Mechanical Turk",
         long_description = long_description,
         url = "http://github.com/NYUCCL/psiturk",
-        test_suite='test_psiturk'
+        test_suite='test_psiturk',
+        data_files=[('$HOME',['psiturk/default_configs/.psiturkconfig'])]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 from psiturk.version import version_number
+import os
 
 try:
     with open("README.md") as readmefile:
@@ -41,6 +42,6 @@ if __name__ == "__main__":
         long_description = long_description,
         url = "http://github.com/NYUCCL/psiturk",
         test_suite='test_psiturk',
-        data_files=[('$HOME',['psiturk/default_configs/.psiturkconfig'])]
+        data_files=[(os.environ['HOME'],['psiturk/default_configs/.psiturkconfig'])]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 from psiturk.version import version_number
-import os
+from os import environ
 
 try:
     with open("README.md") as readmefile:
@@ -42,6 +42,6 @@ if __name__ == "__main__":
         long_description = long_description,
         url = "http://github.com/NYUCCL/psiturk",
         test_suite='test_psiturk',
-        data_files=[(os.environ['HOME'],['psiturk/default_configs/.psiturkconfig'])]
+        data_files=[(environ['HOME'],['psiturk/default_configs/.psiturkconfig'])]
     )
 


### PR DESCRIPTION
I think it is useful to have a sample .psiturkconfig placed into the user's home directory during installation. I'm a new user and this pull request comes from my installation experience. I didn't follow the quickstart guide, so the long version (http://psiturk.readthedocs.org/en/latest/amt_setup.html) has you manually creating/editing the file rather than an example being autogenerated. Based on this experience, I believe adding the default config file at setup is advantageous for two reasons: 1) It assures the user psiTurk is installed properly (I SEE a necessary file in my home directory - it must have worked!) and 2) It helps new users that didn't follow the quickstart more intuitively edit the configuration file so they can see the syntax. I simply copied the example_global_config_defaults.txt and had it placed into home directory during install as .psiturkconfig. Hope this is helpful.

Thanks!