### PR TITLE
ignore other users processes when checking server

### DIFF
--- a/psiturk/experiment_server_controller.py
+++ b/psiturk/experiment_server_controller.py
@@ -136,7 +136,7 @@ class ExperimentServerController:
 
     def is_server_running(self):
         PROCNAME = "psiturk_experiment_server"
-        cmd = "ps -eo pid,command | grep '"+ PROCNAME + "' | grep -v grep | awk '{print $1}'"
+        cmd = "ps -o pid,command | grep '"+ PROCNAME + "' | grep -v grep | awk '{print $1}'"
         psiturk_exp_processes = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         output = psiturk_exp_processes.stdout.readlines()
         psiturk_exp_ports = []


### PR DESCRIPTION
Currently, when checking the server psiTurk searches through ALL user's
processes for psiturk server processes, and thus if a second user is
running a psiturk server it will find these processes and try to
communicate with them, causing an error. If psiturk only searches for
the current user's processes, multiple users should be able to
serve from the same server, as long as they use different ports.