### PR TITLE
update total HIT cost based on new fees

### DIFF
--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -992,8 +992,15 @@ class PsiturkNetworkShell(PsiturkShell):
             else:
                 self.live_hits += 1
             # print results
+            # fee structure changed 07.22.15:
+            # 20% for HITS with < 10 assignments
+            # 40% for HITS with >= 10 assignments
+            commission = 0.2
+            if float(numWorkers) >= 10:
+                commission = 0.4 
+
             total = float(numWorkers) * float(reward)
-            fee = total / 10
+            fee = total * commission
             total = total + fee
             location = ''
             if self.sandbox:


### PR DESCRIPTION
Since Amazon changed its pricing structure on July 22nd, it may be good to report the actual cost of HITs when you create them, rather than reporting the cost with the old 10% commission fee. The change made takes into consideration the number of assignments (20% for < 10 assignments, 40% for >= 10).