### PR TITLE
instructionsnav id and value fix

### DIFF
--- a/psiturk/example/templates/instructions/instruct-2.html
+++ b/psiturk/example/templates/instructions/instruct-2.html
@@ -26,7 +26,7 @@
     <div class="instructionsnav">
         <div class="row">
             <div class="col-xs-2">
-                <button type="button" id="next" value="next" class="btn btn-primary btn-lg previous">
+                <button type="button" id="prev" value="prev" class="btn btn-primary btn-lg previous">
                 <span class="glyphicon glyphicon-arrow-left"></span> Previous
                 </button>
             </div>

--- a/psiturk/example/templates/instructions/instruct-3.html
+++ b/psiturk/example/templates/instructions/instruct-3.html
@@ -26,7 +26,7 @@
     <div class="instructionsnav">
         <div class="row">
             <div class="col-xs-2">
-                <button type="button" id="next" value="next" class="btn btn-primary btn-lg previous">
+                <button type="button" id="prev" value="prev" class="btn btn-primary btn-lg previous">
                 <span class="glyphicon glyphicon-arrow-left"></span> Previous
                 </button>
             </div>


### PR DESCRIPTION
The 'previous' button within the instructionsnav example template had the
same id and value as the 'continue' button.