### PR TITLE
change instructionsnav click handler from `.bind` to `.on`

### DIFF
--- a/psiturk/psiturk_js/psiturk.js
+++ b/psiturk/psiturk_js/psiturk.js
@@ -118,13 +118,13 @@ var PsiTurk = function(uniqueId, adServerLoc, mode) {
 
 			// connect event handler to previous button
 			if(currentscreen != 0) {  // can't do this if first page
-				$('.previous').bind('click.psiturk.instructionsnav.prev', function() {
+				$('.instructionsnav').on('click.psiturk.instructionsnav.prev', '.previous', function() {
 					prevPageButtonPress();
 				});
 			}
 
 			// connect event handler to continue button
-			$('.continue').bind('click.psiturk.instructionsnav.next', function() {
+			$('.instructionsnav').on('click.psiturk.instructionsnav.next', '.continue', function() {
 				nextPageButtonPress();
 			});
 			


### PR DESCRIPTION
`.bind` (which was deprecated in jquery v1.7) can only attach handlers to
matching elements that already exist in the DOM. `.on`, on the other hand,
is dynamic and attaches to elements that may match in the future (and
detaches from elements that stop matching). Changing to `.on` allows a
class of 'continue' or 'previous' to be added to a button at a later time
so that it can act as a forward button.

`.on` needs to be anchored to a parent element that will receive the
bubbled event. the parent element should ideally be as close to the
targeted event elements as possible so decrease bubbling noise. i attached
it to the parent .instructionsnav container.