### PR TITLE
get_workers get all hits

### DIFF
--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -393,8 +393,7 @@ class MTurkServices(object):
         if not self.connect_to_turk():
             return False
         try:
-            hits = self.mtc.search_hits(sort_direction='Descending',
-                                        page_size=20)
+            hits = self.mtc.get_all_hits()
             hit_ids = [hit.HITId for hit in hits]
            
             workers_nested = []


### PR DESCRIPTION
get_workers now called boto's get_all_hits(). One consequence of this edit
is that hits returned are no longer sorted descending by creation date.
this will change the order that the returned workers appear in

Fixes #208 