### PR TITLE
for bonusing, only selects an assignment_id if completion status >= 4

### DIFF
--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -737,7 +737,7 @@ class PsiturkNetworkShell(PsiturkShell):
                 init_db()
                 part = Participant.query.\
                        filter(Participant.assignmentid == assignment_id).\
-                       filter(Participant.endhit != None).\
+                       filter(Participant.status >= 4).\
                        one()
                 if auto:
                     amount = part.bonus


### PR DESCRIPTION
Fixes #190
