### PR TITLE
Generate a random debug string in default.html

### DIFF
--- a/psiturk/example/templates/default.html
+++ b/psiturk/example/templates/default.html
@@ -6,6 +6,7 @@
 		<title>Psychology Experiment</title>
 		<link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css" />
 		<link rel="stylesheet" href="/static/css/style.css" type="text/css" />
+		<script src="/static/lib/jquery-min.js" type="text/javascript"> </script>
 	</head>
 	<body>
 		<div id="container-ad" class="media">
@@ -17,8 +18,27 @@
 						<h1>Welcome to psiTurk!</h1>
 						<hr />
 					    <div class="alert alert-warning">
-					    	Begin by viewing the <a href="/ad">ad</a>.
-					    </div>
+							Begin by viewing the <a href="#" id="ad-href">ad</a>.
+							<script type="text/javascript">
+							function makeid()
+							{
+								var text = "";
+								var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+								for( var i=0; i < 5; i++ )
+									text += possible.charAt(Math.floor(Math.random() * possible.length));
+
+								return text;
+							}
+
+							var assignmentId = "debug" + makeid();
+							var hitId = "debug" + makeid();
+							var workerId = "debug" + makeid();
+							var href = "/ad?assignmentId=" + assignmentId + "&hitId=" + hitId + "&workerId=" + workerId + "&mode=debug"
+
+							$("#ad-href").attr("href", href);
+							</script>
+						</div>
 			</div>
 		</div>
 	</body>

--- a/psiturk/example/templates/default.html
+++ b/psiturk/example/templates/default.html
@@ -15,30 +15,30 @@
 						<img id="adlogo" src="/static/images/university.png" alt="Lab Logo" />
 			</div>
 			<div class="media-body">
-						<h1>Welcome to psiTurk!</h1>
-						<hr />
-					    <div class="alert alert-warning">
-							Begin by viewing the <a href="#" id="ad-href">ad</a>.
-							<script type="text/javascript">
-							function makeid()
-							{
-								var text = "";
-								var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+				<h1>Welcome to psiTurk!</h1>
+				<hr />
+			    <div class="alert alert-warning">
+					Begin by viewing the <a href="#" id="ad-href">ad</a>.
+					<script type="text/javascript">
+					function makeid()
+					{
+						var text = "";
+						var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-								for( var i=0; i < 5; i++ )
-									text += possible.charAt(Math.floor(Math.random() * possible.length));
+						for( var i=0; i < 5; i++ )
+							text += possible.charAt(Math.floor(Math.random() * possible.length));
 
-								return text;
-							}
+						return text;
+					}
 
-							var assignmentId = "debug" + makeid();
-							var hitId = "debug" + makeid();
-							var workerId = "debug" + makeid();
-							var href = "/ad?assignmentId=" + assignmentId + "&hitId=" + hitId + "&workerId=" + workerId + "&mode=debug"
+					var assignmentId = "debug" + makeid();
+					var hitId = "debug" + makeid();
+					var workerId = "debug" + makeid();
+					var href = "/ad?assignmentId=" + assignmentId + "&hitId=" + hitId + "&workerId=" + workerId + "&mode=debug"
 
-							$("#ad-href").attr("href", href);
-							</script>
-						</div>
+					$("#ad-href").attr("href", href);
+					</script>
+				</div>
 			</div>
 		</div>
 	</body>


### PR DESCRIPTION
In the stroop example, the `default.html` page redirects people to the ad page. However, the ad page expects query string arguments, and thus just gives an error. This PR adds a little javascript to `default.html` so that it generates a random set of query string arguments for the ad url, just like you'd get if you ran `debug` from the psiturk command line.

This is particularly useful for directing collaborators to preview experiments that you have running on a server somewhere.