### PR TITLE
Add descriptions for each of the errors

### DIFF
--- a/psiturk/example/templates/error.html
+++ b/psiturk/example/templates/error.html
@@ -39,6 +39,7 @@
                         </p>
                         <p>
                             Error: #{{ errornum }}<br />
+                            Description: {{ errordesc }}<br />
                             {% if hitId %} HITID: #{{ hitId }}<br /> {% endif %}
                             {% if assignId %}AssignmentId: #{{ assignId }}<br /> {% endif %}
                             {% if workerId %} WorkerId: #{{ workerId }}<br /> {% endif %}

--- a/psiturk/example/templates/error.html
+++ b/psiturk/example/templates/error.html
@@ -37,12 +37,13 @@
                             <a href="mailto:{{contact_address}}">{{contact_address}}</a>
                             and send the following information:
                         </p>
+                        <hr />
                         <p>
-                            Error: #{{ errornum }}<br />
-                            Description: {{ errordesc }}<br />
-                            {% if hitId %} HITID: #{{ hitId }}<br /> {% endif %}
-                            {% if assignId %}AssignmentId: #{{ assignId }}<br /> {% endif %}
-                            {% if workerId %} WorkerId: #{{ workerId }}<br /> {% endif %}
+                            <b>Error</b>: {{ errornum }}<br />
+                            <b>Description</b>: {{ errordesc }}<br />
+                            {% if hitId %}<b>HITId</b>: #{{ hitId }}<br /> {% endif %}
+                            {% if assignId %}<b>AssignmentId</b>: #{{ assignId }}<br /> {% endif %}
+                            {% if workerId %}<b>WorkerId</b>: #{{ workerId }}<br /> {% endif %}
                         </p>
 
                 </div>

--- a/psiturk/experiment_errors.py
+++ b/psiturk/experiment_errors.py
@@ -5,43 +5,149 @@
 
 from flask import render_template
 
+
+def unwrap(string):
+    return " ".join([x.strip() for x in string.split("\n")]).strip()
+
+
 class ExperimentError(Exception):
     """
     Error class for experimental errors, such as subject not being found in
     the database.
     """
+
+    experiment_errors = dict(
+        status_incorrectly_set=1000,
+        hit_assign_worker_id_not_set_in_mturk=1001,
+        hit_assign_worker_id_not_set_in_consent=1002,
+        hit_assign_worker_id_not_set_in_exp=1003,
+        hit_assign_appears_in_database_more_than_once=1004,
+        already_started_exp=1008,
+        already_started_exp_mturk=1009,
+        already_did_exp_hit=1010,
+        tried_to_quit=1011,
+        intermediate_save=1012,
+        improper_inputs=1013,
+        browser_type_not_allowed=1014,
+        api_server_not_reachable=1015,
+        ad_not_found=1016,
+        error_setting_worker_complete=1017,
+        hit_not_registered_with_ad_server=1018,
+        template_unsafe=1019,
+        insert_mode_failed=1020,
+        page_not_found=404,
+        in_debug=2005,
+        unknown_error=9999
+    )
+
+    error_descriptions = dict()
+    error_descriptions['status_incorrectly_set'] = unwrap(
+        """
+        Participant tried to access the ad, but their status in the database
+        isn't something I know how to handle.
+        """)
+
+    error_descriptions['hit_assign_worker_id_not_set_in_mturk'] = unwrap(
+        """
+        Either the HIT id or the assignment id were not provided in the URL for
+        the ad page.
+        """)
+
+    error_descriptions['hit_assign_worker_id_not_set_in_consent'] = unwrap(
+        """
+        Either the HIT id, the assignment id, or the worker id were not
+        provided in the URL for the consent form page.
+        """)
+
+    error_descriptions['hit_assign_worker_id_not_set_in_exp'] = unwrap(
+        """
+        Either the HIT id, the assignment id, the worker id, or the mode were
+        not provided in the URL for the experiment page.
+        """)
+
+    error_descriptions['hit_assign_appears_in_database_more_than_once'] = unwrap(
+        """
+        The requested HIT or assignment appears in the database more than once.
+        """)
+
+    error_descriptions['already_started_exp'] = unwrap(
+        """
+        The experiment was requested, but cannot be continued because it was
+        already started and ended prematurely.
+        """)
+
+    error_descriptions['already_started_exp_mturk'] = unwrap(
+        """
+        The ad was requested, but the experiment cannot be continued because it
+        was already started and ended prematurely.
+        """)
+
+    error_descriptions['already_did_exp_hit'] = unwrap(
+        """
+        The experiment has already been completed.
+        """)
+
+    error_descriptions['tried_to_quit'] = unwrap(
+        """
+        The experiment was ended prematurely and something went wrong while
+        writing to the database.
+        """)
+
+    error_descriptions['improper_inputs'] = unwrap(
+        """
+        The uniqueId was not provided in the URL, but it is required.
+        """)
+
+    error_descriptions['browser_type_not_allowed'] = unwrap(
+        """
+        The browser you are using is not allowed by this experiment.
+        """)
+
+    error_descriptions['api_server_not_reachable'] = unwrap(
+        """
+        The psiTurk API server is unreachable.
+        """)
+
+    error_descriptions['error_setting_worker_complete'] = unwrap(
+        """
+        The experiment was completed but something went wrong while writing to
+        the database.
+        """)
+
+    error_descriptions['hit_not_registered_with_ad_server'] = unwrap(
+        """
+        The requested HIT is not registered with the psiTurk ad server.
+        """)
+
+    error_descriptions['insert_mode_failed'] = unwrap(
+        """
+        Failed to insert the 'mode' query string argument in the URL.
+        """)
+
+    error_descriptions['page_not_found'] = unwrap(
+        """
+        The requested page does not exist.
+        """)
+
+    error_descriptions['intermediate_save'] = ""
+    error_descriptions['ad_not_found'] = ""
+    error_descriptions['template_unsafe'] = ""
+    error_descriptions['in_debug'] = ""
+    error_descriptions['unknown_error'] = ""
+
     def __init__(self, value):
-        experiment_errors = dict(
-            status_incorrectly_set = 1000,
-            hit_assign_worker_id_not_set_in_mturk = 1001,
-            hit_assign_worker_id_not_set_in_consent = 1002,
-            hit_assign_worker_id_not_set_in_exp = 1003,
-            hit_assign_appears_in_database_more_than_once = 1004,
-            already_started_exp = 1008,
-            already_started_exp_mturk = 1009,
-            already_did_exp_hit = 1010,
-            tried_to_quit= 1011,
-            intermediate_save = 1012,
-            improper_inputs = 1013,
-            browser_type_not_allowed = 1014,
-            api_server_not_reachable = 1015,
-            ad_not_found = 1016,
-            error_setting_worker_complete = 1017,
-            hit_not_registered_with_ad_server = 1018,
-            template_unsafe = 1019,
-            insert_mode_failed = 1020,
-            page_not_found = 404,
-            in_debug = 2005,
-            unknown_error = 9999
-        )
         self.value = value
-        self.errornum = experiment_errors[self.value]
+        self.errornum = self.experiment_errors[self.value]
+        self.errordesc = self.error_descriptions[self.value]
         self.template = "error.html"
 
     def __str__(self):
         return repr(self.value)
+
     def error_page(self, request, contact_on_error):
-        return render_template(self.template,
-                               errornum = self.errornum,
-                               contact_address = contact_on_error,
-                               **request.args)
+        return render_template(
+            self.template,
+            errornum=self.errornum,
+            errordesc=self.errordesc,
+            contact_address=contact_on_error,
+            **request.args)

--- a/test_psiturk.py
+++ b/test_psiturk.py
@@ -81,12 +81,12 @@ class PsiTurkStandardTests(PsiturkUnitTest):
     def test_exp_debug_no_url_vars(self):
         '''Test that exp page throws Error #1003 with no url vars.'''
         rv = self.app.get('/exp')
-        assert 'Error: #1003' in rv.data
+        assert '<b>Error</b>: 1003' in rv.data
 
     def test_ad_no_url_vars(self):
         '''Test that ad page throws Error #1001 with no url vars.'''
         rv = self.app.get('/ad')
-        assert 'Error: #1001' in rv.data
+        assert '<b>Error</b>: 1001' in rv.data
 
     def test_ad_with_all_urls(self):
         '''Test that ad page throws Error #1003 with no url vars.'''
@@ -106,7 +106,7 @@ class PsiTurkStandardTests(PsiturkUnitTest):
             'hitId=debug%s' % self.hit_id,
             'mode=sandbox'])
         rv = self.app.get('/exp?%s' % args)
-        assert 'Error: #1018' in rv.data
+        assert '<b>Error</b>: 1018' in rv.data
 
     def test_sync_put(self):
         request = "&".join([
@@ -185,7 +185,7 @@ class BadUserAgent(PsiturkUnitTest):
             '/ad' + '?assignmentId=debug' + self.assignment_id + '&workerId=debug' +
             self.worker_id + '&hitId=debug' + self.hit_id + '&mode=sandbox'
         )
-        assert 'Error: #1014' in rv.data
+        assert '<b>Error</b>: 1014' in rv.data
 
 
 class PsiTurkTestPsiturkJS(PsiturkUnitTest):
@@ -218,6 +218,19 @@ class PsiTurkTestPsiturkJS(PsiturkUnitTest):
         super(PsiTurkTestPsiturkJS, self).tearDown()
         os.chdir('psiturk-example')
         os.rename(self.PSITURK_JS_FILE + '.bup', self.PSITURK_JS_FILE)
+
+
+class ExperimentErrorsTest(PsiturkUnitTest):
+
+    def test_experiment_errors(self):
+        """Make sure every error has a description"""
+        error_cls = psiturk.experiment_errors.ExperimentError
+
+        for error_name in error_cls.experiment_errors:
+            assert error_name in error_cls.error_descriptions
+
+        for error_name in error_cls.error_descriptions:
+            assert error_name in error_cls.experiment_errors
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #89 and adds a bunch of descriptions to go with each of the errors. There were a few errors that didn't seem to be used anywhere, so I didn't really know what description to put with them:

* intermediate_save
* ad_not_found
* template_unsafe
* in_debug
* unknown_error

I gave them empty strings for now but really there are I think two options which would be better:

1. Remove these errors since they are no longer used
2. If they should be kept in, give them a non-empty string for the description