### PR TITLE
Allow repeat participants

### DIFF
--- a/doc/config/hit_configuration.rst
+++ b/doc/config/hit_configuration.rst
@@ -19,6 +19,7 @@ like this:
 	psiturk_keywords = stroop
 	organization_name = New Great University
 	browser_exclude_rule = MSIE, mobile, tablet
+    allow_repeats = false
 
 
 `title` [string]
@@ -162,3 +163,13 @@ standard computers (sort of the opposite to the `mobile` and `tablet` exclusions
 Finally `bot` tries to exclude web spiders and non-browser agents like
 the Unix curl command.
 
+`allow_repeats` [boolean]
+-------------------------
+`allow_repeats` specifies whether participants may complete the experiment more
+than once. If it is set to `false` (the default), then participants will be
+blocked from completing the experiment more than once. If it is set to `true`,
+then participants will be able to complete the experiment any number of times.
+
+Note that this option does not affect the behavior when a participant starts
+the experiment but the quits or refreshes the page. In those cases, they will
+still be locked out, regardless of the setting of `allow_repeats`.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -83,6 +83,7 @@ project:
 	psiturk_keywords = stroop
 	organization_name = New Great University
 	browser_exclude_rule = MSIE, mobile, tablet
+    allow_repeats = false
 
 	[Database Parameters]
 	database_url = sqlite:///participants.db

--- a/psiturk/default_configs/local_config_defaults.txt
+++ b/psiturk/default_configs/local_config_defaults.txt
@@ -10,6 +10,7 @@ ad_group = Default psiTurk Stroop Example
 psiturk_keywords = stroop
 organization_name = New Great University
 browser_exclude_rule = MSIE, mobile, tablet
+allow_repeats = false
 
 [Database Parameters]
 database_url = sqlite:///participants.db

--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -258,6 +258,7 @@ def advertisement():
     except exc.SQLAlchemyError:
         status = None
 
+    allow_repeats = CONFIG.getboolean('HIT Configuration', 'allow_repeats')
     if status == STARTED and not debug_mode:
         # Once participants have finished the instructions, we do not allow
         # them to start the task again.
@@ -273,7 +274,7 @@ def advertisement():
             assignmentid=assignment_id,
             workerid=worker_id
         )
-    elif already_in_db and not debug_mode:
+    elif already_in_db and not (debug_mode or allow_repeats):
         raise ExperimentError('already_did_exp_hit')
     elif status == ALLOCATED or not status or debug_mode:
         # Participant has not yet agreed to the consent. They might not
@@ -351,9 +352,17 @@ def start_exp():
 
     # Check first to see if this hitId or assignmentId exists.  If so, check to
     # see if inExp is set
-    matches = Participant.query.\
-        filter(Participant.workerid == worker_id).\
-        all()
+    allow_repeats = CONFIG.getboolean('HIT Configuration', 'allow_repeats')
+    if allow_repeats:
+        matches = Participant.query.\
+            filter(Participant.workerid == worker_id).\
+            filter(Participant.assignmentid == assignment_id).\
+            all()
+    else:
+        matches = Participant.query.\
+            filter(Participant.workerid == worker_id).\
+            all()
+
     numrecs = len(matches)
     if numrecs == 0:
         # Choose condition and counterbalance

--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -259,7 +259,7 @@ def advertisement():
         status = None
 
     allow_repeats = CONFIG.getboolean('HIT Configuration', 'allow_repeats')
-    if status == STARTED and not debug_mode:
+    if (status == STARTED or status == QUITEARLY) and not debug_mode:
         # Once participants have finished the instructions, we do not allow
         # them to start the task again.
         raise ExperimentError('already_started_exp_mturk')

--- a/test_psiturk.py
+++ b/test_psiturk.py
@@ -53,6 +53,7 @@ class PsiturkUnitTest(unittest.TestCase):
         psiturk.experiment.app.wsgi_app = FlaskTestClientProxy(
             psiturk.experiment.app.wsgi_app)
         self.app = psiturk.experiment.app.test_client()
+        self.config = psiturk.experiment.CONFIG
         psiturk.db.init_db()
 
         # Fake MTurk data
@@ -66,6 +67,9 @@ class PsiturkUnitTest(unittest.TestCase):
         os.chdir('..')
         os.unlink(psiturk.experiment.app.config['DATABASE'])
         self.app = None
+
+    def set_config(self, section, field, value):
+        self.config.parent.set(self.config, section, field, str(value))
 
 
 class PsiTurkStandardTests(PsiturkUnitTest):
@@ -153,6 +157,115 @@ class PsiTurkStandardTests(PsiturkUnitTest):
     def test_favicon(self):
         '''Test that favicon loads.'''
         rv = self.app.get('/favicon.ico')
+        assert rv.status_code == 200
+
+    def test_complete_experiment(self):
+        '''Test that a participant can start and finish the experiment.'''
+        request = "&".join([
+            "assignmentId=debug%s" % self.assignment_id,
+            "workerId=debug%s" % self.worker_id,
+            "hitId=debug%s" % self.hit_id,
+            "mode=debug"])
+
+        # put the user in the database
+        rv = self.app.get("/exp?%s" % request)
+        assert rv.status_code == 200
+
+        # save data with sync PUT
+        uniqueid = "debug%s:debug%s" % (self.worker_id, self.assignment_id)
+        rv = self.app.put('/sync/%s' % uniqueid)
+        assert rv.status_code == 200
+
+        # complete experiment
+        rv = self.app.get('/complete?uniqueId=%s' % uniqueid)
+        assert rv.status_code == 200
+
+    def test_repeat_experiment_fail(self):
+        '''Test that a participant cannot repeat the experiment.'''
+        request = "&".join([
+            "assignmentId=%s" % self.assignment_id,
+            "workerId=%s" % self.worker_id,
+            "hitId=%s" % self.hit_id,
+            "mode=debug"])
+
+        # put the user in the database
+        rv = self.app.get("/exp?%s" % request)
+        assert rv.status_code == 200
+
+        # save data with sync PUT
+        uniqueid = "%s:%s" % (self.worker_id, self.assignment_id)
+        rv = self.app.put('/sync/%s' % uniqueid)
+        assert rv.status_code == 200
+
+        # complete experiment
+        rv = self.app.get('/complete?uniqueId=%s' % uniqueid)
+        assert rv.status_code == 200
+
+        # choose new assignment and hit ids
+        self.assignment_id = fake.md5(raw_output=False)
+        self.hit_id = fake.md5(raw_output=False)
+        request = "&".join([
+            "assignmentId=%s" % self.assignment_id,
+            "workerId=%s" % self.worker_id,
+            "hitId=%s" % self.hit_id,
+            "mode=debug"])
+
+        # make sure they are blocked on the ad page
+        rv = self.app.get('/ad?%s' % request)
+        assert 'Error: #1010' in rv.data
+
+        # make sure they are blocked on the experiment page
+        rv = self.app.get("/exp?%s" % request)
+        assert 'Error: #1010' in rv.data
+
+    def test_repeat_experiment_success(self):
+        '''Test that a participant can repeat the experiment.'''
+        self.set_config('HIT Configuration', 'allow_repeats', 'true')
+        request = "&".join([
+            "assignmentId=%s" % self.assignment_id,
+            "workerId=%s" % self.worker_id,
+            "hitId=%s" % self.hit_id,
+            "mode=debug"])
+
+        # put the user in the database
+        rv = self.app.get("/exp?%s" % request)
+        assert rv.status_code == 200
+
+        # save data with sync PUT
+        uniqueid = "%s:%s" % (self.worker_id, self.assignment_id)
+        rv = self.app.put('/sync/%s' % uniqueid)
+        assert rv.status_code == 200
+
+        # complete experiment
+        rv = self.app.get('/complete?uniqueId=%s' % uniqueid)
+        assert rv.status_code == 200
+
+        # choose new assignment and hit ids
+        self.assignment_id = fake.md5(raw_output=False)
+        self.hit_id = fake.md5(raw_output=False)
+        request = "&".join([
+            "assignmentId=%s" % self.assignment_id,
+            "workerId=%s" % self.worker_id,
+            "hitId=%s" % self.hit_id,
+            "mode=debug"])
+
+        # make sure they are not blocked on the ad page
+        rv = self.app.get('/ad?%s' % request)
+        assert rv.status_code == 200
+        assert 'Error: #1010' not in rv.data
+
+        # make sure they are not blocked on the experiment page
+        rv = self.app.get("/exp?%s" % request)
+        assert rv.status_code == 200
+        assert 'Error: #1010' not in rv.data
+
+        # save data with sync PUT
+        uniqueid = "%s:%s" % (self.worker_id, self.assignment_id)
+        rv = self.app.put('/sync/%s' % uniqueid)
+        assert rv.status_code == 200
+
+        # complete experiment
+        rv = self.app.get('/complete?uniqueId=%s' % uniqueid)
         assert rv.status_code == 200
 
 


### PR DESCRIPTION
Fixes #90 though it doesn't do anything about toggling whether the instructions are shown or not. I figured that should probably be a separate PR. I also added tests to make sure that the toggle works as expected and either blocks or does not block participants from completing the experiment.

Note that this will still block participants who started the experiment but quit early, regardless of the setting of `allow_repeats`.
