### PR TITLE
fixes "MySQL Server has gone away" error for long-term experiments

### DIFF
--- a/psiturk/db.py
+++ b/psiturk/db.py
@@ -19,7 +19,7 @@ if 'mysql' in config.get('Database Parameters', 'database_url').lower():
 			  "Installation can be tricky on some systems.")
 		exit()
 
-engine = create_engine(DATABASE, echo=False) 
+engine = create_engine(DATABASE, echo=False, pool_recycle=3600) 
 db_session = scoped_session(sessionmaker(autocommit=False,
                                          autoflush=False,
                                          bind=engine))


### PR DESCRIPTION
MySQL defaults to closing connections that have been inactive for 8
hours, which will result in the “MySQL Server has gone away” error if
you have a long-term, low-traffic experiment (e.g., if you want to
leave a server up for a one-session-per-day experiment). Setting the
pool_recycle=3600 flag in the create_engine call forces SQLAlchemy to
hourly refresh DBAPI connections.