### PR TITLE
Adds browser_exclude_rule for Safari

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -219,6 +219,11 @@ def advertisement():
                (myrule == "pc" and user_agent_obj.is_pc) or\
                (myrule == "bot" and user_agent_obj.is_bot):
                 browser_ok = False
+        elif (myrule == "Safari" or myrule == "safari"):
+            if "Chrome" in user_agent_string and "Safari" in user_agent_string:
+                pass
+            elif "Safari" in user_agent_string:
+                browser_ok = False
         elif myrule in user_agent_string:
             browser_ok = False
 


### PR DESCRIPTION
This fixes #219. As disscussed in #219, Google Chrome userAgent strings
include the word Safari. Because of this, trying to exclude Safari also
excludes Google Chrome.

The value for Safari userAgent strings just includes Safari and not
Google Chrome. Therefore, this problem can be fixed by first checking if
both "Chrome" and "Safari" are in the userAgent string. If this is true,
then we do not want to exclude it, so we do nothing. If this check
returns False, then we still want to check to see if "Safari" is in the
userAgent string because that is what we want to exclude. If it is, then
we exclude it.