### PR TITLE
Fixing the readthedocs link to be an external link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ your name and email address match your git configuration.
 
 ## Contributing to the docs
 
-Our docs are currently hosted at [readthedocs](psiturk.readthedocs.org). 
+Our docs are currently hosted at [readthedocs](http://psiturk.readthedocs.org). 
 Readthedocs uses [Sphinx](http://sphinx-doc.org/) as the backend for their
 documentation so in order to update the docs you will first have to install
 Sphinx simply by typing


### PR DESCRIPTION
Just adding the protocol to make it an external link