### PR TITLE
Use own ad server

### DIFF
--- a/doc/config/server_parameters.rst
+++ b/doc/config/server_parameters.rst
@@ -7,16 +7,18 @@ command line.  An example looks like this:
 
 ::
 
-	[Server Parameters]
-	host = 0.0.0.0
-	port = 22362
-	cutoff_time = 30
-	logfile = server.log
-	loglevel = 2
-	debug = true
-	login_username = examplename
-	login_pw = examplepassword
-	threads = auto
+    [Server Parameters]
+    host = 0.0.0.0
+    port = 22362
+    cutoff_time = 30
+    logfile = server.log
+    loglevel = 2
+    debug = true
+    login_username = examplename
+    login_pw = examplepassword
+    threads = auto
+    #certfile = <path_to.crt> 
+    #keyfile = <path_to.key>
 
 `host` [ string]
 --------------
@@ -91,3 +93,46 @@ the the psiturk webserver will run.  This enables multiple
 simultanous connections from internet users.  If you select
 `auto` it will set this based on the number of processor
 cores on your current computer.
+
+`certfile` [ string ]
+----------------------
+.. warning::
+    
+    SSL support for the psiturk server is an experimental feature.
+
+`certfile` should be the /path/to/your/domain/SSL.crt
+    
+If both certfile and keyfile are set and the files readable, then 
+the psiturk gunicorn server will run with ssl. You will need 
+to execute the psiturk with privileges sufficient to read 
+the keyfile (typically root). If you run `psiturk` with `sudo` and if you are using
+a virtual environment, make sure to execute the full path to the desired psiturk instance in your environment. 
+See `launch-sudo-psiturk in this gist`_ for an example.
+
+If you want to do this, you are responsible for obtaining 
+your own cert and key. It is not necessary to run the 
+psiturk server with `ssl` in order to use your own ad server.
+You can have a proxy server such as `nginx` in front of 
+psiturk/gunicorn which handles ssl connections. See `this gist`_ for an example.
+
+See http://docs.gunicorn.org/en/stable/deploy.html for more information on setting up proxy servers with the psiturk (gunicorn) server.
+
+.. seealso::
+
+    `use_psiturk_ad_server <shell_parameters.html#use-psiturk-ad-server-true-false>`__
+        How to use your on ad_location. Does not require that the **psiTurk** server be SSL-enabled. (Although you will still need your own SSL certificate and key)
+
+`keyfile` [ string ]
+----------------------
+.. warning::
+    
+    SSL support for the psiturk server is an experimental feature.
+
+`certfile` should be the /path/to/your/domain/private-SSL.key. Although .crts can contain .key files within them,
+psiturk currently requires that you point to separate .crt and .key files for this experimental feature to work.
+
+See the documentation for `certfile` for more information.
+
+.. _launch-sudo-psiturk in this gist: gist_
+.. _this gist: gist_
+.. _gist: https://gist.github.com/deargle/5d8c01660a77b8090a2cd24efcda2c59

--- a/doc/config/server_parameters.rst
+++ b/doc/config/server_parameters.rst
@@ -113,14 +113,14 @@ If you want to do this, you are responsible for obtaining
 your own cert and key. It is not necessary to run the 
 psiturk server with `ssl` in order to use your own ad server.
 You can have a proxy server such as `nginx` in front of 
-psiturk/gunicorn which handles ssl connections. See `this gist`_ for an example.
+psiturk/gunicorn which handles ssl connections. See `this gist`_ for an example. **However, if you configure the psiturk server to run with SSL by setting the `certfile` and `keyfile` here, you must use a proxy server in front of psiturk to serve the content in your /static folder. An SSL-enabled psiturk/gunicorn server will not serve static content -- it will only serve dynamic content.**
 
 See http://docs.gunicorn.org/en/stable/deploy.html for more information on setting up proxy servers with the psiturk (gunicorn) server.
 
 .. seealso::
 
     `use_psiturk_ad_server <shell_parameters.html#use-psiturk-ad-server-true-false>`__
-        How to use your on ad_location. Does not require that the **psiTurk** server be SSL-enabled. (Although you will still need your own SSL certificate and key)
+        How to use your own ad_location. Does not require that the **psiTurk** server be SSL-enabled. (Although you will still need your own SSL certificate and key)
 
 `keyfile` [ string ]
 ----------------------

--- a/doc/config/shell_parameters.rst
+++ b/doc/config/shell_parameters.rst
@@ -20,3 +20,64 @@ to `true` to lessen the chance of accidentally posting a live HIT to mTurk.
 
    `Overview of the command-line interface <../command_line_overview.html>`__
    	  The basic features of the **psiTurk** command line.
+      
+`use_psiturk_ad_server` [true | false]
+---------------------------------------
+
+.. warning::
+    
+    Non-use of the psiturk ad server is an experimental feature.
+
+If set to `true`, then the **psiTurk** secure ad server functionality will be enabled,
+and your ad will be hosted on psiturk.org when creating hits on AMT.
+
+If you want to host your own ad, then set this to `false`. You are responsible for obtaining 
+your own cert and key and for configuring your own proxy server in front
+of psiturk/gunicorn. It is not necessary to also include the cert and key
+in the [Server Parameters] section -- you can have a proxy server 
+such as nginx in front of psiturk/gunicorn which handles SSL connections.
+Although if you don't have your SSL certs in both places, then traffic between
+your proxy server and psiturk/gunicorn will not be encrypted. Perhaps that
+doesn't matter to you though if you configure your proxy server to pass traffic
+to your gunicorn/psiturk server via localhost.
+
+If set to `false` then you must also specify your custom `ad_location` (see below).
+
+.. seealso::
+
+    See the `[Server Parameters] certfile and keyfile configs <server_parameters.html>`__
+    for ssl-enabling the psiturk server (although this is not required to use your 
+    own ad location).
+    
+.. seealso::
+    
+    See `this gist`_ for an example nginx psiturk SSL configuration
+    
+
+`ad_location` [false | string]
+------------------------------
+
+.. warning::
+    
+    Non-use of the psiturk ad server is an experimental feature.
+    
+`ad_location` is only used if `use_psiturk_ad_server` is `false`. 
+Set to whatever you set up your proxy server to listen on. This will be sent directly 
+to AMT when creating your HITs to tell AMT where to look for your ad.
+
+Format is as follows::
+
+    https://<host>:<port>/ad
+    
+Some gotcha's:
+
+* don't forget the `/ad` at the end. And don't append a trailing backslash.
+* you must use `https://` or AMT will explode.
+* the `<port>` should be the port your *proxy server* (such as nginx) is running on, *not* the **psiturk** port. See the `gist`_ for a full example.
+
+.. seealso::
+
+    See the information for the `use_psiturk_ad_server` configuration above as well.
+
+.. _this gist: gist_
+.. _gist: https://gist.github.com/deargle/5d8c01660a77b8090a2cd24efcda2c59

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -71,41 +71,47 @@ project:
 
 ::
 
-	[HIT Configuration]
-	title = Stroop task
-	description = Judge the color of a series of words.
-	amt_keywords = Perception, Psychology
-	lifetime = 24
-	us_only = true
-	approve_requirement = 95
-	contact_email_on_error = youremail@gmail.com
-	ad_group = My research project
-	psiturk_keywords = stroop
-	organization_name = New Great University
-	browser_exclude_rule = MSIE, mobile, tablet
+    [HIT Configuration]
+    title = Stroop task
+    description = Judge the color of a series of words.
+    amt_keywords = Perception, Psychology
+    lifetime = 24
+    us_only = true
+    approve_requirement = 95
+    contact_email_on_error = youremail@gmail.com
+    ad_group = Default psiTurk Stroop Example
+    psiturk_keywords = stroop
+    organization_name = New Great University
+    browser_exclude_rule = MSIE, mobile, tablet
 
-	[Database Parameters]
-	database_url = sqlite:///participants.db
-	table_name = turkdemo
+    [Database Parameters]
+    database_url = sqlite:///participants.db
+    table_name = turkdemo
 
-	[Server Parameters]
-	host = 0.0.0.0
-	port = 22362
-	cutoff_time = 30
-	logfile = server.log
-	loglevel = 2
-	debug = true
-	login_username = examplename
-	login_pw = examplepassword
-	threads = auto
+    [Server Parameters]
+    host = localhost
+    port = 22362
+    cutoff_time = 30
+    logfile = server.log
+    loglevel = 2
+    debug = true
+    login_username = examplename
+    login_pw = examplepassword
+    threads = auto
+    secret_key = 'this is my secret key which is hard to guess, i should change this'    
+    #certfile = <path_to.crt> 
+    #keyfile = <path_to.key>
 
-	[Task Parameters]
-	experiment_code_version = 1.0
-	num_conds = 1
-	num_counters = 1
+    [Task Parameters]
+    experiment_code_version = 1.0
+    num_conds = 1
+    num_counters = 1
 
-	[Shell Parameters]
-	launch_in_sandbox_mode = true
+    [Shell Parameters]
+    launch_in_sandbox_mode = true
+    use_psiturk_ad_server = true
+    ad_location = false
+
 
 This file is divided into a few sections which are
 described in detail.  Each field is described by

--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -632,8 +632,8 @@ class MTurkServices(object):
         try:
             self.mtc.dispose_hit(hitid)
         except Exception, e:
-            print 'Failed to dispose of HIT %s. Make sure there are no "\
-                "assignments remaining to be reviewed' % hitid
+            print "Failed to dispose of HIT %s. Make sure there are no "\
+                "assignments remaining to be reviewed." % hitid
 
     def extend_hit(self, hitid, assignments_increment=None,
                    expiration_increment=None):

--- a/psiturk/default_configs/local_config_defaults.txt
+++ b/psiturk/default_configs/local_config_defaults.txt
@@ -36,7 +36,10 @@ num_counters = 1
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
+
+# If you are not using the psiturk ad server, set `use_psiturk_ad_server` to `false` and point `ad_location` to your proxy server <host> and <port>. Format the ad_location like this:
+#
+#   https://<host>:<port>/ad 
+
 use_psiturk_ad_server = true
-ad_location = false # https://<host>:<port>/ad, 
-                    # point this to your proxy server <host> and <port> 
-                    # if you are not using the psiturk_ad_server
+ad_location = false

--- a/psiturk/default_configs/local_config_defaults.txt
+++ b/psiturk/default_configs/local_config_defaults.txt
@@ -45,6 +45,7 @@ secret_key = 'this is my secret key which is hard to guess, i should change this
 #certfile = <path_to.crt> 
 #keyfile = <path_to.key>
 
+
 [Task Parameters]
 experiment_code_version = 1.0
 num_conds = 1
@@ -66,4 +67,5 @@ launch_in_sandbox_mode = true
 # See http://docs.gunicorn.org/en/stable/deploy.html
 
 use_psiturk_ad_server = true
-ad_location = false # https://<host>:<port>/ad -- only used if `use_psiturk_ad_server` is false. Set to whatever you set up your proxy server to listen on.
+ad_location = false # https://<host>:<port>/ad -- only used if `use_psiturk_ad_server` 
+                    # is false. Set to whatever you set up your proxy server to listen on.

--- a/psiturk/default_configs/local_config_defaults.txt
+++ b/psiturk/default_configs/local_config_defaults.txt
@@ -26,25 +26,8 @@ login_username = examplename
 login_pw = examplepassword
 threads = auto
 secret_key = 'this is my secret key which is hard to guess, i should change this'
-
-# If both certfile and keyfile are present and readable, then 
-# the psiturk gunicorn server will run with ssl. You will need 
-# to execute the psiturk with privileges sufficient to read 
-# the keyfile (typically root). If you run `psiturk` with sudo, 
-# make sure to execute the full path to the desired psiturk instance in your (virtual) environment. 
-# See `launch-sudo-psiturk` for an example.
-
-# If you want to do this, you are responsible for obtaining 
-# your own cert and key. It is not necessary to run the 
-# psiturk server with ssl in order to use your own ad server.
-# You can have a proxy server such as nginx in front of 
-# psiturk/gunicorn which handles ssl connections.
-
-# See http://docs.gunicorn.org/en/stable/deploy.html
-
 #certfile = <path_to.crt> 
 #keyfile = <path_to.key>
-
 
 [Task Parameters]
 experiment_code_version = 1.0
@@ -53,19 +36,7 @@ num_counters = 1
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
-
-# If you want to host your own ad, you are responsible for obtaining 
-# your own cert and key and for configuring your own proxy server in front
-# of psiturk/gunicorn. It is not necessary to include the cert and key
-# in the [Server Parameters] section above -- You can have a proxy server 
-# such as nginx in front of psiturk/gunicorn which handles ssl connections.
-# Although if you don't have your certs in both places, then traffic between
-# your proxy server and psiturk/gunicorn will not be encrypted. Perhaps that
-# doesn't matter to you though if you configure your proxy server to pass traffic
-# to your gunicorn/psiturk server via localhost.
-
-# See http://docs.gunicorn.org/en/stable/deploy.html
-
 use_psiturk_ad_server = true
-ad_location = false # https://<host>:<port>/ad -- only used if `use_psiturk_ad_server` 
-                    # is false. Set to whatever you set up your proxy server to listen on.
+ad_location = false # https://<host>:<port>/ad, 
+                    # point this to your proxy server <host> and <port> 
+                    # if you are not using the psiturk_ad_server

--- a/psiturk/default_configs/local_config_defaults.txt
+++ b/psiturk/default_configs/local_config_defaults.txt
@@ -27,6 +27,24 @@ login_pw = examplepassword
 threads = auto
 secret_key = 'this is my secret key which is hard to guess, i should change this'
 
+# If both certfile and keyfile are present and readable, then 
+# the psiturk gunicorn server will run with ssl. You will need 
+# to execute the psiturk with privileges sufficient to read 
+# the keyfile (typically root). If you run `psiturk` with sudo, 
+# make sure to execute the full path to the desired psiturk instance in your (virtual) environment. 
+# See `launch-sudo-psiturk` for an example.
+
+# If you want to do this, you are responsible for obtaining 
+# your own cert and key. It is not necessary to run the 
+# psiturk server with ssl in order to use your own ad server.
+# You can have a proxy server such as nginx in front of 
+# psiturk/gunicorn which handles ssl connections.
+
+# See http://docs.gunicorn.org/en/stable/deploy.html
+
+#certfile = <path_to.crt> 
+#keyfile = <path_to.key>
+
 [Task Parameters]
 experiment_code_version = 1.0
 num_conds = 1
@@ -34,3 +52,18 @@ num_counters = 1
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
+
+# If you want to host your own ad, you are responsible for obtaining 
+# your own cert and key and for configuring your own proxy server in front
+# of psiturk/gunicorn. It is not necessary to include the cert and key
+# in the [Server Parameters] section above -- You can have a proxy server 
+# such as nginx in front of psiturk/gunicorn which handles ssl connections.
+# Although if you don't have your certs in both places, then traffic between
+# your proxy server and psiturk/gunicorn will not be encrypted. Perhaps that
+# doesn't matter to you though if you configure your proxy server to pass traffic
+# to your gunicorn/psiturk server via localhost.
+
+# See http://docs.gunicorn.org/en/stable/deploy.html
+
+use_psiturk_ad_server = true
+ad_location = false # https://<host>:<port>/ad -- only used if `use_psiturk_ad_server` is false. Set to whatever you set up your proxy server to listen on.

--- a/psiturk/example/static/css/style.css
+++ b/psiturk/example/static/css/style.css
@@ -11,80 +11,67 @@ body {
 
 /* text styling */
 strong {
-    font-weight: 600;         
+  font-weight: 600;         
 }
 
 .warm {
-    color: steelblue;
-    text-align: justify;
+  color: steelblue;
+  text-align: justify;
 }
 
 .cool {
-    color: #ccccff;
+  color: #ccccff;
 }
 
 h1 {
-    margin-top: 0px;
+  margin-top: 0px;
 }
+
 
 /* these are all the same for now, but easy to modify individually */
 #container-ad, #container-error, #container-exp, #container-consent, #container-instructions, #container-questionnaire {
-    position: absolute;
-    top: 0px; /* Header Height */
-    bottom: 0px; /* Footer Height */
-    left: 0px;
-    right: 0px;
-    padding: 100px;
-    padding-top: 5%;
-    border: 18px solid #f3f3f3;
     background: white;
-}
-
-#container-consent, #container-exp {  /* override padding to fit long consent forms and exp display*/
-    padding: 10px;
-    padding-left: 20px;
-    padding-right: 20px;
-    padding-top: 1%;
+    margin: 30px;
 }
 
 /* ad.html  - the ad that people view first */
 #adlogo {
-    float: right;
     width: 140px;
     padding: 2px;
     border: 1px solid #ccc;
+    margin-right: 1em;
 }
 
 /* consent.html - the consent form */
 #consent {
-    margin: 0 auto;
-    margin-top: 0;
-    width: 800px;
-    font-size: 100%;
+  margin: 0 auto;
+  margin-top: 0;
+  width: 800px;
+  font-size: 100%;
 }
 
 .legal {
-    text-align: justify;
-    font-size: 11pt;
-    line-height: 1.1em;
+  text-align: justify;
+  font-size: 11pt;
+  line-height: 1.1em;
 }
 
 #trial {
-    margin: 0 auto;
-    width: 800px;
-    text-align: center;
+  margin: 0 auto;
+  width: 800px;
+  text-align: center;
 }
 
 #query {
-    color: darkgray;
+  color: darkgray;
 }
 
 .question {
-    margin-bottom: 30px;
+  margin-bottom: 30px;
 }
 
 /* errors */
 #error img {
-    padding-right: 10px;
-    padding-top: 15px;
+  padding-right: 10px;
+  padding-top: 15px;
 }

--- a/psiturk/example/static/css/style.css
+++ b/psiturk/example/static/css/style.css
@@ -11,67 +11,80 @@ body {
 
 /* text styling */
 strong {
-  font-weight: 600;         
+    font-weight: 600;         
 }
 
 .warm {
-  color: steelblue;
-  text-align: justify;
+    color: steelblue;
+    text-align: justify;
 }
 
 .cool {
-  color: #ccccff;
+    color: #ccccff;
 }
 
 h1 {
-  margin-top: 0px;
+    margin-top: 0px;
 }
-
 
 /* these are all the same for now, but easy to modify individually */
 #container-ad, #container-error, #container-exp, #container-consent, #container-instructions, #container-questionnaire {
+    position: absolute;
+    top: 0px; /* Header Height */
+    bottom: 0px; /* Footer Height */
+    left: 0px;
+    right: 0px;
+    padding: 100px;
+    padding-top: 5%;
+    border: 18px solid #f3f3f3;
     background: white;
-    margin: 30px;
+}
+
+#container-consent, #container-exp {  /* override padding to fit long consent forms and exp display*/
+    padding: 10px;
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-top: 1%;
 }
 
 /* ad.html  - the ad that people view first */
 #adlogo {
+    float: right;
     width: 140px;
     padding: 2px;
     border: 1px solid #ccc;
-    margin-right: 1em;
 }
 
 /* consent.html - the consent form */
 #consent {
-  margin: 0 auto;
-  margin-top: 0;
-  width: 800px;
-  font-size: 100%;
+    margin: 0 auto;
+    margin-top: 0;
+    width: 800px;
+    font-size: 100%;
 }
 
 .legal {
-  text-align: justify;
-  font-size: 11pt;
-  line-height: 1.1em;
+    text-align: justify;
+    font-size: 11pt;
+    line-height: 1.1em;
 }
 
 #trial {
-  margin: 0 auto;
-  width: 800px;
-  text-align: center;
+    margin: 0 auto;
+    width: 800px;
+    text-align: center;
 }
 
 #query {
-  color: darkgray;
+    color: darkgray;
 }
 
 .question {
-  margin-bottom: 30px;
+    margin-bottom: 30px;
 }
 
 /* errors */
 #error img {
-  padding-right: 10px;
-  padding-top: 15px;
+    padding-right: 10px;
+    padding-top: 15px;
 }

--- a/psiturk/example/templates/closepopup.html
+++ b/psiturk/example/templates/closepopup.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+    <head>
+        <title>Returning to Mechanical Turk</title>
+        <script>
+            window.opener.location.reload(true);
+            window.close();
+        </script>
+    </head>
+    <body>
+        <h1>Returning to HIT window.</h1>
+        <p>You are being redirected back to the HIT window, which should refresh.
+        If you do not see the HIT submission form when you return, try refreshing
+        the page.</p>
+    </body>
+</html>

--- a/psiturk/example/templates/thanks-mturksubmit.html
+++ b/psiturk/example/templates/thanks-mturksubmit.html
@@ -1,0 +1,44 @@
+<html><head>
+        <title>Psychology Experiment - Thanks</title>
+        <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css">
+        <link rel="stylesheet" href="/static/css/style.css" type="text/css">
+        <script src="/static/lib/jquery-min.js" type="text/javascript"> </script>
+        <script>
+            function complete_amt_task() {
+                // reload trials
+                $.ajax({
+                    dataType: "json",
+                    type: "GET",
+                    url: "/worker_submitted?uniqueId={{ workerid }}:{{ assignmentid }}", // this needs to be the location of the 'submitted' listener for the server
+                    success: function (data) {
+                        $( "#mturk_form" ).submit();
+                    }
+                });
+            };
+        </script>
+    </head>
+    <body>
+        <div id="container-ad">
+            <div class="well">
+                <h1>Thanks for your participation</h1>
+                <hr>
+
+                <p>To complete the HIT, simply press the button below.</p>
+
+                {% if using_sandbox %}
+                    <form style="width: auto;" id="mturk_form" action="https://workersandbox.mturk.com/mturk/externalSubmit" method="post">
+                {% else %}
+                    <form style="width: auto;" id="mturk_form" action="https://www.mturk.com/mturk/externalSubmit" method="post">
+                {% endif %}
+                        <input type="hidden" id="assignmentId" name="assignmentId" value="{{ assignmentid }}"> 
+                        <input type="hidden" id="hitId" name="hitId" value="{{ hitid }}"> 
+                        <input type="hidden" id="workerId" name="workerId" value="{{ workerid }}"> 
+                    </form>
+
+                    <button class="btn btn-success btn-lg" onclick="complete_amt_task();">
+                        Complete HIT
+                    </button>
+
+                </div>
+
+    </div></body></html>

--- a/psiturk/example/templates/thanks-mturksubmit.html
+++ b/psiturk/example/templates/thanks-mturksubmit.html
@@ -5,13 +5,16 @@
         <script src="/static/lib/jquery-min.js" type="text/javascript"> </script>
         <script>
             function complete_amt_task() {
-                // reload trials
+                $(window).on('beforeunload', function(){
+                    return 'Your submission is in progress. If you leave now, your assignment data will be corrupted.';
+                });
                 $.ajax({
                     dataType: "json",
                     type: "GET",
                     url: "/worker_submitted?uniqueId={{ workerid }}:{{ assignmentid }}",
                     success: function (data) {
                         $( "#mturk_form" ).submit();
+                        $(window).off('beforeunload');
                     }
                 });
             };

--- a/psiturk/example/templates/thanks-mturksubmit.html
+++ b/psiturk/example/templates/thanks-mturksubmit.html
@@ -9,7 +9,7 @@
                 $.ajax({
                     dataType: "json",
                     type: "GET",
-                    url: "/worker_submitted?uniqueId={{ workerid }}:{{ assignmentid }}", // this needs to be the location of the 'submitted' listener for the server
+                    url: "/worker_submitted?uniqueId={{ workerid }}:{{ assignmentid }}",
                     success: function (data) {
                         $( "#mturk_form" ).submit();
                     }

--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -276,12 +276,6 @@ def advertisement():
                 workerid=worker_id
             )
         else: 
-            # `thanks.html` was taken out in v2 with the introduction of the psiturk ad server
-            # but put back in in v2.1.2 because "local thanks page needed when reloading the 
-            # local ad and a worker has already completed the task." As far as I, @deargle, can interpret,
-            # a user, be they an AMT worker or not, should not typically reach this page unless 
-            # they're fooling around with URLs.
-            # 
             # Show them a thanks message and tell them to go away.
             return render_template( 'thanks.html' )
     elif already_in_db and not debug_mode:

--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -263,11 +263,11 @@ def advertisement():
         # them to start the task again.
         raise ExperimentError('already_started_exp_mturk')
     elif status == COMPLETED:
-        # They've finished the experiment but perhaps haven't submitted the HIT
-        # yet.. Turn asignmentId into original assignment id before sending it
-        # back to AMT
         use_psiturk_ad_server = CONFIG.getboolean('Shell Parameters', 'use_psiturk_ad_server')
         if not use_psiturk_ad_server:
+            # They've finished the experiment but haven't submitted the HIT
+            # yet.. Turn asignmentId into original assignment id before sending it
+            # back to AMT
             return render_template(
                 'thanks-mturksubmit.html',
                 using_sandbox=(mode == "sandbox"),
@@ -276,7 +276,13 @@ def advertisement():
                 workerid=worker_id
             )
         else: 
-            # then AMT isn't involved. Show them a thanks message and tell them to go away
+            # `thanks.html` was taken out in v2 with the introduction of the psiturk ad server
+            # but put back in in v2.1.2 because "local thanks page needed when reloading the 
+            # local ad and a worker has already completed the task." As far as I, @deargle, can interpret,
+            # a user, be they an AMT worker or not, should not typically reach this page unless 
+            # they're fooling around with URLs.
+            # 
+            # Show them a thanks message and tell them to go away.
             return render_template( 'thanks.html' )
     elif already_in_db and not debug_mode:
         raise ExperimentError('already_did_exp_hit')

--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -582,6 +582,10 @@ def debug_complete():
         raise ExperimentError('improper_inputs')
     else:
         unique_id = request.args['uniqueId']
+        if unique_id[:5] == "debug":
+            debug_mode = True
+        else:
+            debug_mode = False
         try:
             user = Participant.query.\
                 filter(Participant.uniqueid == unique_id).one()
@@ -592,8 +596,7 @@ def debug_complete():
         except:
             raise ExperimentError('error_setting_worker_complete')
         else:
-            use_psiturk_ad_server = CONFIG.getboolean('Shell Parameters', 'use_psiturk_ad_server')
-            if use_psiturk_ad_server:
+            if debug_mode:
                 return render_template('complete.html')
             else: # send them back to mturk.
                 return render_template('closepopup.html')

--- a/psiturk/experiment_server.py
+++ b/psiturk/experiment_server.py
@@ -64,6 +64,15 @@ class ExperimentServer(Application):
             'limit_request_line': '0'
         }
 
+        if config.has_option("Server Parameters", "certfile") and config.has_option("Server Parameters", "keyfile"):
+            print "Loading SSL certs for server..."
+            ssl_options = {
+                'certfile' : config.get("Server Parameters", "certfile"),
+                'keyfile' : config.get("Server Parameters", "keyfile")
+            }
+            self.user_options.update(ssl_options)
+
+
 def launch():
     ExperimentServer().run()
 

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -864,6 +864,7 @@ class PsiturkNetworkShell(PsiturkShell):
     def hit_create(self, numWorkers, reward, duration):
 
         server_loc = str(self.config.get('Server Parameters', 'host'))
+        inaccessible_but_do_it_anyways = False
         if server_loc in ['localhost', '127.0.0.1']:
             print '\n'.join(['*****************************',
             "  Sorry, your server is set for local debugging only.  You cannot",\
@@ -881,6 +882,8 @@ class PsiturkNetworkShell(PsiturkShell):
                           ))
             if user_input != 'y':
                 return
+            else:
+                inaccessible_but_do_it_anyways = True
         
         use_psiturk_ad_server = self.config.getboolean('Shell Parameters', 'use_psiturk_ad_server')
 
@@ -901,7 +904,7 @@ class PsiturkNetworkShell(PsiturkShell):
                              '  credentials via the Amazon AMT requester website.\n'])
             return
 
-        if self.server.is_server_running() != 'yes':
+        if self.server.is_server_running() != 'yes' and not inaccessible_but_do_it_anyways:
             print '\n'.join(['*****************************',
                              '  Your psiTurk server is currently not running but you are trying to create ',
                              '  an Ad/HIT.  This can cause problems for worker trying to access your ',

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -952,17 +952,17 @@ class PsiturkNetworkShell(PsiturkShell):
             else:
                 print '\n'.join(['*****************************',
                                  '  Sorry, there was an error registering ad.',
-                                 '  Both ad.html is required to be in the templates folder',
-                                 '  of your project so that these Ad can be served!'])
+                                 '  The file ad.html is required to be in the templates folder',
+                                 '  of your project so that the ad can be served.'])
                 return
 
             size_of_ad = sys.getsizeof(ad_html)
             if size_of_ad >= 1048576:
                 print '\n'.join(['*****************************',
-                                 '  Sorry, there was an error registering ad.',
+                                 '  Sorry, there was an error registering the ad.',
                                  '  Your local ad.html is %s byes, but the maximum',
-                                 '  template size uploadable to the Ad server is',
-                                 '  1048576 bytes!' % size_of_ad])
+                                 '  template size uploadable to the ad server is',
+                                 '  1048576 bytes.' % size_of_ad])
                 return
 
             # what all do we need to send to server?

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -1065,13 +1065,13 @@ class PsiturkNetworkShell(PsiturkShell):
             total = float(numWorkers) * float(reward)
             fee = total * commission
             total = total + fee
-            location = ''
+            mode = ''
             if self.sandbox:
-                location = 'sandbox'
+                mode = 'sandbox'
             else:
-                location = 'live'
+                mode = 'live'
             print '\n'.join(['*****************************',
-                             '  Creating %s HIT' % colorize(location, 'bold'),
+                             '  Creating %s HIT' % colorize(mode, 'bold'),
                              '    HITid: %s' % str(hit_id),
                              '    Max workers: %s' % numWorkers,
                              '    Reward: $%s' %reward,
@@ -1079,24 +1079,42 @@ class PsiturkNetworkShell(PsiturkShell):
                              '    Fee: $%.2f' % fee,
                              '    ________________________',
                              '    Total: $%.2f' % total])
-            if self.sandbox:
-                if use_psiturk_ad_server:
-                    print('  Ad URL: https://sandbox.ad.psiturk.org/view/%s?assignmentId=debug%s&hitId=debug%s&workerId=debug%s'
-                          % (str(ad_id), str(self.random_id_generator()), str(self.random_id_generator()), str(self.random_id_generator())))
-                    print "Note: This url cannot be used to run your full psiTurk experiment.  It is only for testing your ad."
-                print('  Sandbox URL: https://workersandbox.mturk.com/mturk/searchbar?selectedSearchType=hitgroups&searchWords=%s'
-                      % (urllib.quote_plus(str(self.config.get('HIT Configuration', 'title')))))
-                print "Hint: In OSX, you can open a terminal link using cmd + click"
-                print "Note: This sandboxed ad will expire from the server in 16 days."
-            else:
-                if use_psiturk_ad_server:
-                    print('  Ad URL: https://ad.psiturk.org/view/%s?assignmentId=debug%s&hitId=debug%s&workerId=debug%s'
-                          % (str(ad_id), str(self.random_id_generator()), str(self.random_id_generator()), str(self.random_id_generator())))
-                    print "Note: This url cannot be used to run your full psiTurk experiment.  It is only for testing your ad."
-                print('  MTurk URL: https://www.mturk.com/mturk/searchbar?selectedSearchType=hitgroups&searchWords=%s'
-                        % (urllib.quote_plus(str(self.config.get('HIT Configuration', 'title')))))
-                print "Hint: In OSX, you can open a terminal link using cmd + click"
 
+            # Print the Ad Url
+            ad_url = ''
+            if use_psiturk_ad_server:
+                if self.sandbox:
+                    ad_url_base = 'https://sandbox.ad.psiturk.org/view'
+                else:
+                    ad_url_base = 'https://ad.psiturk.org/view'
+                ad_url = '{}/{}?assignmentId=debug{}&hitId=debug{}&workerId=debug{}'.format( 
+                    ad_url_base, str(ad_id), str(self.random_id_generator()), str(self.random_id_generator()), str(self.random_id_generator()))
+
+            else:
+                options = { 
+                    'base': self.config.get('Shell Parameters', 'ad_location'), 
+                    'mode': mode,
+                    'assignmentid': str(self.random_id_generator()),
+                    'hitid': str(self.random_id_generator()),
+                    'workerid': str(self.random_id_generator())
+                  }
+                ad_url = '{base}?mode={mode}&assignmentId=debug{assignmentid}&hitId=debug{hitid}&workerId=debug{workerid}'.format(**options)
+            print('  Ad URL: {}'.format(ad_url) )
+            print "Note: This url cannot be used to run your full psiTurk experiment.  It is only for testing your ad."
+
+            # Print the Mturk Url
+            mturk_url = ''
+            if self.sandbox:
+                mturk_url_base = 'https://workersandbox.mturk.com'
+            else:
+                mturk_url_base = 'https://www.mturk.com'
+            mturk_url = '{}/mturk/searchbar?selectedSearchType=hitgroups&searchWords={}'.format(
+                mturk_url_base, urllib.quote_plus(str(self.config.get('HIT Configuration', 'title'))) )
+
+            print('  MTurk URL: {}'.format(mturk_url) )
+            print "Hint: In OSX, you can open a terminal link using cmd + click"
+            if self.sandbox and use_psiturk_ad_server:
+                print "Note: This sandboxed ad will expire from the server in 16 days."
 
     @docopt_cmd
     def do_db(self, arg):

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -310,7 +310,7 @@ class PsiturkShell(Cmd, object):
     config_commands = ('print', 'reload', 'help')
 
     def complete_config(self, text, line, begidx, endidx):
-        ''' Not sure what this does... '''
+        ''' Tab-complete config command '''
         return  [i for i in PsiturkShell.config_commands if i.startswith(text)]
 
     def help_config(self):
@@ -454,7 +454,7 @@ class PsiturkShell(Cmd, object):
     server_commands = ('on', 'off', 'restart', 'log', 'help')
 
     def complete_server(self, text, line, begidx, endidx):
-        ''' Not sure what this does... '''
+        ''' Tab-complete server command '''
         return  [i for i in PsiturkShell.server_commands if i.startswith(text)]
 
     def help_server(self):
@@ -1115,6 +1115,7 @@ class PsiturkNetworkShell(PsiturkShell):
                    'aws_delete_instance', 'help')
 
     def complete_db(self, text, line, begidx, endidx):
+        ''' Tab-complete db command '''
         return  [i for i in PsiturkNetworkShell.db_commands if \
                  i.startswith(text)]
 
@@ -1622,7 +1623,7 @@ class PsiturkNetworkShell(PsiturkShell):
     hit_commands = ('create', 'extend', 'expire', 'dispose', 'list')
 
     def complete_hit(self, text, line, begidx, endidx):
-        ''' Complete HIT. '''
+        ''' Tab-complete hit command. '''
         return  [i for i in PsiturkNetworkShell.hit_commands if \
                  i.startswith(text)]
 
@@ -1661,7 +1662,7 @@ class PsiturkNetworkShell(PsiturkShell):
     worker_commands = ('approve', 'reject', 'unreject', 'bonus', 'list', 'help')
 
     def complete_worker(self, text, line, begidx, endidx):
-        ''' Complete worker. '''
+        ''' Tab-complete worker command. '''
         return  [i for i in PsiturkNetworkShell.worker_commands if \
                  i.startswith(text)]
 

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -1066,7 +1066,7 @@ class PsiturkNetworkShell(PsiturkShell):
         if size_of_ad >= 1048576:
             print '\n'.join(['*****************************',
                 '  Sorry, there was an error registering the ad.',
-                '  Your local ad.html is %s byes, but the maximum',
+                '  Your local ad.html is %s bytes, but the maximum',
                 '  template size uploadable to the ad server is',
                 '  1048576 bytes.' % size_of_ad])
             return


### PR DESCRIPTION
Okay here goes. This is functionality for toggling the use of the psiturk ad server. Look in the new comments in psiturk/default_configs/local_config_defaults.txt for an overview of the changes. See [this gist][the gist] for an example config. Here's a summary of the process:

1. You can say whether you want to use psiturk's ad server. Default is `true`.
2. If you don't, then just say so and also set an `ad_location` url in the config for the location of your psiturk ad route. This url should point to a proxy server running in front psiturk/gunicorn. I used nginx. See [the gist referenced above][the gist] for a config that works for psiturk (and for flask/gunicorn/nginx in general). Your proxy server will need to handle SSL. You will need to get your own certs right now if you want to do this.
3. You can optionally also have gunicorn work with SSL. If you want to to do this, set paths to both `keyfile` and `certfile` in the `[Server Parameters]` section. Assuming your process has permissions necessary to read the keyfile, they'll be loaded into gunicorn (see [the same gist as before][the gist] for an example of launching psiturk with sudo while still using the proper virtualenv binaries). If you do this, make sure that you switch the url of your proxy_pass in nginx to use the `https://` protocol.

[the gist]: https://gist.github.com/deargle/5d8c01660a77b8090a2cd24efcda2c59

Some other changes:

1. I also copied the slightly-updated styles.css from psiturk.org to the static/css files so that formatting on the "thanks-mturksubmit.html" file matches what happens if using the psiturk ad server. Sorry for the spacing creating lots of line changes, blame vim auto-formatting.
2. I'm bringing back `closepopup.html` from the dead. Also bringing back the old `thanks.html` and calling it `thanks-mturksubmit.html` so that it has the nice submit button thing. Leaving the 2.0 `thanks.html` alone.

Even if this isn't merged, it demonstrates how to go about the process.

Also see #121 