### PR TITLE
this `atkill` handler does _not_ do what it claims. It claims to hand…

### DIFF
--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -15,7 +15,6 @@ import datetime
 import urllib
 import signal
 from fuzzywuzzy import process
-import atexit
 
 from cmd2 import Cmd
 from docopt import docopt, DocoptExit
@@ -1837,14 +1836,3 @@ def run(cabinmode=False, script=None):
         signal.signal(signal.SIGINT, handler)
         shell.cmdloop()
 
-    @atexit.register
-    def clean_up():
-        ''' Catch abrupt keyboard interrupts '''
-        try:
-            if (shell.server.is_server_running() == 'yes' or
-                    shell.server.is_server_running() == 'maybe'):
-                shell.server_off()
-            if not cabinmode:
-                shell.tunnel.close()
-        except:
-            pass


### PR DESCRIPTION
…le keyboard interrupts but that is precisely what the module is designed to not do. what this codeblock _does_ do is kill the server whenever `psiturk -s` is invoked. That's bad. `psiturk -s` should shut down its own servers if that is what the user wants to do. other code already handles shutting down the server on invocation of `exit` or `server off`. this code simply has to go.

Closes #227 