### PR TITLE
notify user when ctrl-c kills experiment server

### DIFF
--- a/psiturk/experiment_server.py
+++ b/psiturk/experiment_server.py
@@ -53,6 +53,17 @@ class ExperimentServer(Application):
 
         self.loglevels = ["debug", "info", "warning", "error", "critical"]
 
+        def on_exit(server):
+            ''' 
+            this is hooked so that it can be called when 
+            the server is shut down via CTRL+C. Otherwise
+            there is no notification to the user that the server
+            has shut down until they hit `enter` and see that 
+            the cmdloop prompt suddenly says "server off"
+            '''
+            print 'Caught ^C, experiment server has shut down.'
+            print 'Press `enter` to continue.'
+
         self.user_options = {
             'bind': config.get("Server Parameters", "host") + ":" + config.get("Server Parameters", "port"),
             'workers': workers,
@@ -61,7 +72,8 @@ class ExperimentServer(Application):
             # 'accesslog': config.get("Server Parameters", "logfile"),
             'errorlog': config.get("Server Parameters", "logfile"),
             'proc_name': 'psiturk_experiment_server',
-            'limit_request_line': '0'
+            'limit_request_line': '0',
+            'on_exit': on_exit
         }
 
 def launch():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 argparse==1.2.1
 Flask==0.10.1
 SQLAlchemy==0.8.3
-gunicorn==18.0
+gunicorn==19.4.5
 boto==2.15.0
 cmd2==0.6.7
 docopt==0.6.2


### PR DESCRIPTION
gunicorn's `on_exit` is hooked so that it can be called when
the server is shut down via CTRL+C. Otherwise
there is no notification to the user that the server
has shut down until they hit `enter` and see that
the cmdloop prompt suddenly says "server off"

unfortunatley detection of ctrl+c can't be handled reliably
by psiturk_shell even by checking `server.is_server_running()`
because gunicorn shuts down its workers asynchronously and
therefore status will sometimes be read before, during, or after
everything has shutdown

requires gunicorn >= 19.0 though (when the on_exit hook was
implemented). Everything works with the most recent gunicorn (19.4.5)

Closes #229