### PR TITLE
changing the error message for RDS connections for IAM users

### DIFF
--- a/doc/amt_setup.rst
+++ b/doc/amt_setup.rst
@@ -77,6 +77,11 @@ We recommend that you also download your access keys just in case. The "Download
 The values of these keys need to be placed in your global ``~/.psiturkconfig`` file. The file is by default located in your home directory
 (see `Configuration files <configuration.html>`__ for more info)
 
+.. note::
+
+    If you are using IAM authentication, **psiTurk** requires that the *AmazonMechanicalTurkFullAccess* policy be added to the credentials it uses to connect to MTurk.
+    See `here <http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMechanicalTurkGettingStartedGuide/SetUp.html#create-iam-user-or-role>`__ for how to set up an IAM user.
+
 Creating an AMT Requester account
 ----------------------------------
 

--- a/doc/configure_databases.rst
+++ b/doc/configure_databases.rst
@@ -159,9 +159,13 @@ interface with the Amazon cloud.
 
 .. note::
 
-	Of course, you must have valid AWS credentials to use this system.  See
-	`Getting setup with Amazon Mechanical Turk <amt_setup.html>`__ and
-	`Global configuration file <configuration.html#global-configuration-file>`__.
+    Of course, you must have valid AWS credentials to use this system.  See
+    `Getting setup with Amazon Mechanical Turk <amt_setup.html>`__ and
+    `Global configuration file <configuration.html#global-configuration-file>`__.
+    
+    If you are using psiturk with an IAM user, and if you want to use AWS RDB services via psiturk,
+    add the *AmazonRDSFullAccess* AWS policy or an equivalent custom policy to your IAM user.
+    See AWS docs `here <http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.AccessControl.IdentityBased.html#UsingWithRDS.IAM.AccessControl.ManagedPolicies>`__.
 
 
 AWS Regions

--- a/doc/configure_databases.rst
+++ b/doc/configure_databases.rst
@@ -380,3 +380,14 @@ end of the month (you may not realize the charges until later).
 The point is that using a free MySQL database hosted by your university or another
 provider may be better, but this solution is available for researchers who can 
 afford to pay the hosting fee and would like everything in one place.
+
+Obtaining a free MySQL database via OpenShift
+-------------------------------------------------------
+
+If you are hosting your experiment on OpenShift, if you add a `MySQL` cartridge to your gear, **psiTurk** will automatically
+save data to that db instead of to whatever is specified in your `database_url` config. OpenShift gears, including using MySQL 
+cartridges, are free unless you change default configuration settings.
+
+.. seealso ::
+
+    `PsiTurk OpenShift documentation <openshift.html>`__.

--- a/doc/openshift.rst
+++ b/doc/openshift.rst
@@ -1,6 +1,10 @@
 Using psiTurk on OpenShift
 ===================
 
+.. note::
+
+    Consider trying the `OpenShift PsiTurk cartridge <https://github.com/deargle/openshift-psiturk-cartridge>`__. It involves less configuration, and you automatically 
+    get an nginx server in front of psiturk.
 
 Get an OpenShift account
 --------------------------
@@ -78,7 +82,6 @@ To put it all together, this is what your first OpenShift session could look lik
     $ psiturk # Start psiturk
 
 Before you can go live, remember to change the global config file ("/app-root/data/.psiturkconfig").
-
 
 
 

--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -136,16 +136,27 @@ class RDSServices(object):
                 print "*** Unable to establish connection to AWS region %s "\
                     "using your access key/secret key", self.region
                 return False
-            except boto.exception.BotoServerError:
+            except boto.exception.BotoServerError as e:
                 print "***********************************************************"
                 print "WARNING"
-                print "Unable to establish connection to AWS."
+                print "Unable to establish connection to AWS RDS services (relational database services)."
+                print
                 print "While your keys may be valid, your AWS account needs a "
-                print "subscription to certain services.  If you haven't been asked"
+                print "subscription to certain services to perform AWS database commands. If you haven't been asked"
                 print "to provide a credit card and verified your account using your "
                 print "phone, it means your keys are not completely set up yet."
                 print "Please refer to "
                 print "\thttp://psiturk.readthedocs.org/en/latest/amt_setup.html"
+                print
+                print "Note:"
+                print "If you are using psiturk with an IAM user, and if you want to use AWS RDB services via psiturk, "
+                print "add the `AmazonRDSFullAccess` AWS policy or an equivalent custom policy to your IAM user." 
+                print "See AWS docs here: "
+                print "\thttp://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.AccessControl.IdentityBased.html#UsingWithRDS.IAM.AccessControl.ManagedPolicies"
+                print 
+                print "and relevant psiturk docs here:"
+                print "\thttp://psiturk.readthedocs.io/en/latest/configure_databases.html#obtaining-a-low-cost-or-free-mysql-database-on-amazon-s-web-services-cloud"
+
                 print "***********************************************************"
                 return False
             else:

--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -139,24 +139,9 @@ class RDSServices(object):
             except boto.exception.BotoServerError as e:
                 print "***********************************************************"
                 print "WARNING"
-                print "Unable to establish connection to AWS RDS services (relational database services)."
-                print
-                print "While your keys may be valid, your AWS account needs a "
-                print "subscription to certain services to perform AWS database commands. If you haven't been asked"
-                print "to provide a credit card and verified your account using your "
-                print "phone, it means your keys are not completely set up yet."
-                print "Please refer to "
-                print "\thttp://psiturk.readthedocs.org/en/latest/amt_setup.html"
-                print
-                print "Note:"
-                print "If you are using psiturk with an IAM user, and if you want to use AWS RDB services via psiturk, "
-                print "add the `AmazonRDSFullAccess` AWS policy or an equivalent custom policy to your IAM user." 
-                print "See AWS docs here: "
-                print "\thttp://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.AccessControl.IdentityBased.html#UsingWithRDS.IAM.AccessControl.ManagedPolicies"
-                print 
-                print "and relevant psiturk docs here:"
+                print "Unable to establish connection to AWS RDS (Amazon relational database services)."
+                print "See relevant psiturk docs here:"
                 print "\thttp://psiturk.readthedocs.io/en/latest/configure_databases.html#obtaining-a-low-cost-or-free-mysql-database-on-amazon-s-web-services-cloud"
-
                 print "***********************************************************"
                 return False
             else:


### PR DESCRIPTION
December 2015 AWS enabled IAM access control for Mturk. This commit
edits the error message to be DB-services specific. Right now it makes
users think that their credentials aren't good for anything, but
actually the message here is only triggered if RDB services can't be
accessed.

Other commits should maybe change other login messages too to be more
specific, but this is a start.

Sorry for the obscene length but at least the message is informative!

see [this group
thread](https://groups.google.com/forum/#!topic/psiturk/1nx8D-tsE74)