### PR TITLE
use openshift db cartridge, if one is installed

### DIFF
--- a/psiturk/db.py
+++ b/psiturk/db.py
@@ -1,13 +1,18 @@
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.ext.declarative import declarative_base
 from psiturk_config import PsiturkConfig
+import re, os
 
 config = PsiturkConfig()
 config.load_config()
 
-DATABASE = config.get('Database Parameters', 'database_url')
+r = re.compile("OPENSHIFT_(.+)_DB_URL") # Might be MYSQL or POSTGRESQL
+matches = filter(r.match, os.environ)
+if matches:
+    DATABASE = "{}{}".format(os.environ[matches[0]], os.environ['OPENSHIFT_APP_NAME'])
+else:
+    DATABASE = config.get('Database Parameters', 'database_url')
 
 if 'mysql' in config.get('Database Parameters', 'database_url').lower():
 	try:


### PR DESCRIPTION
openshift will host mysql or postgresql relational DBs for you, if you
add those cartridges. this commit tells db.py to use the first installed
openshift db it finds. note that it is theoretically possible to have
both postgresql and mysql addon cartridges installed at the same time.
don't do that, that would be silly.

No editing config.txt required -- the location of the openshift db can
change, so relying on the env vars is really the best way to go. and
it's not easy to integrate the env vars into config.txt.

See README at https://github.com/deargle/openshift-psiturk-cartridge for
an example of getting mysql up and running.