### PR TITLE
Record mode and full useragent string in backbone model

### DIFF
--- a/psiturk/psiturk_js/psiturk.js
+++ b/psiturk/psiturk_js/psiturk.js
@@ -43,11 +43,13 @@ var PsiTurk = function(uniqueId, adServerLoc, mode) {
 			data: [],
 			questiondata: {},
 			eventdata: [],
-			useragent: ""
+			useragent: "",
+			mode: ""
 		},
 		
 		initialize: function() {
-			this.useragent = navigator.userAgent;
+			this.set({ useragent: navigator.userAgent });
+			this.set({ mode: this.mode });
 			this.addEvent('initialized', null);
 			this.addEvent('window_resize', [window.innerWidth, window.innerHeight]);
 


### PR DESCRIPTION
this stashes the mode in the db (live, sandbox, debug). this can be
helpful when doing analyses later down the line in case one needs to
distinguish between live and sandbox assignments in the db. the mode is
stored as part of the taskdata datastring

also, this fixes a neighboring bug where the full useragent string
wasn't actually being saved to the taskdata datastring by backbone