### PR TITLE
Adding a reference to the LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include psiturk/default_configs *
 recursive-include psiturk/psiturk_js *
 recursive-include psiturk/tunnel *
 include requirements.txt
+include LICENSE


### PR DESCRIPTION
I've gone ahead and made a `conda` package out of this repo for distribution via the community-curated `conda-forge` channel. (If y'all want to help maintain it, that would be cool, but is unrelated.) We've started included links to license files in the conda builds themselves, but doing so requires that the license be in the manifest itself. If this pull gets incorporated into the next pypi version, that would let us include said link.