### PR TITLE
import gnureadline if available

### DIFF
--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -18,7 +18,11 @@ from fuzzywuzzy import process
 
 from cmd2 import Cmd
 from docopt import docopt, DocoptExit
-import readline
+
+try:
+    import gnureadline as readline
+except ImportError:
+    import readline
 
 import webbrowser
 import sqlalchemy as sa


### PR DESCRIPTION
I don't pretend to be expert in mac environments, but explicitly importing gnureadline fixes broken things

see #173