### PR TITLE
fixing the boto version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse==1.2.1
 Flask==0.10.1
 SQLAlchemy==0.8.3
 gunicorn==19.4.5
-boto==2.15.0
+boto==2.45.0
 cmd2==0.6.7
 docopt==0.6.2
 requests==2.2.1


### PR DESCRIPTION
boto 0.15 causes python 3 to crash (bad print statement)