### PR TITLE
Add qualification requirements to HIT type (Fixes #263)

### DIFF
--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -540,7 +540,7 @@ class MTurkServices(object):
             hit_config['duration'],
             keywords=hit_config['keywords'],
             approval_delay=None,
-            qual_req=None)[0]
+            qual_req=quals)[0]
 
         # Check the config file to see if notifications are wanted.
         config = PsiturkConfig()


### PR DESCRIPTION
Makes the `us_only` and `approve_requirement` settings in the configuration file have the intended effects.  Fixes #263.