### PR TITLE
better language detection (fixes #270)

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -405,8 +405,8 @@ def start_exp():
             request.user_agent.browser
         platform = "UNKNOWN" if not request.user_agent.platform else \
             request.user_agent.platform
-        language = "UNKNOWN" if not request.user_agent.language else \
-            request.user_agent.language
+        language = "UNKNOWN" if not request.accept_languages else \
+            request.accept_languages.best
 
         # Set condition here and insert into database.
         participant_attributes = dict(


### PR DESCRIPTION
Use the [Accept-Language](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language) HTTP header instead of the [User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) header to detect a participant's preferred language.  This allows language detection in recent versions of most common browsers that no longer include language preferences in the user agent string.