### PR TITLE
Added confirmation dialog to hit_create()

### DIFF
--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -891,7 +891,7 @@ class PsiturkNetworkShell(PsiturkShell):
             self.live_hits = num_hits
 
     def hit_create(self, numWorkers, reward, duration):
-
+        ''' Create a HIT '''
         server_loc = str(self.config.get('Server Parameters', 'host'))
         inaccessible_but_do_it_anyways = False
         if not self.quiet:
@@ -949,8 +949,7 @@ class PsiturkNetworkShell(PsiturkShell):
                 if user_input != 'y':
                     return
 
-        # Validate arguments
-        # numWorkers
+        # Argument retrieval and validation
         if numWorkers is None:
             numWorkers = raw_input('number of participants? ').strip()
         try:
@@ -962,7 +961,6 @@ class PsiturkNetworkShell(PsiturkShell):
             print '*** number of participants must be greater than 0'
             return
 
-        # reward
         if reward is None:
             reward = raw_input('reward per HIT? ').strip()
         p = re.compile('^\d*\.\d\d$')
@@ -976,7 +974,6 @@ class PsiturkNetworkShell(PsiturkShell):
             print '*** reward must be in format [dollars].[cents]'
             return
             
-        # duration
         if duration is None:
             duration = raw_input(
                 'duration of hit (in hours, it can be decimals)? ').strip()
@@ -988,10 +985,12 @@ class PsiturkNetworkShell(PsiturkShell):
         if duration <= 0:
             print '*** duration must be greater than 0'
             return
-        
 
+        if not self._confirm_dialog('Create HIT? [y/n]: '):
+            print '*** Cancelling HIT creation.'
+            return
+            
         if use_psiturk_ad_server:
-
             ad_id = self.create_psiturk_ad() 
             create_failed = False
             fail_msg = None
@@ -1011,7 +1010,6 @@ class PsiturkNetworkShell(PsiturkShell):
                 fail_msg = "  Unable to create Ad on http://ad.psiturk.org."
 
         else: # not using psiturk ad server
-
             mode = 'sandbox' if self.sandbox else 'live'
             ad_location = "{}?mode={}".format(self.config.get('Shell Parameters', 'ad_location'), mode )
             hit_config = self.generate_hit_config(ad_location, numWorkers, reward, duration)
@@ -1093,6 +1091,16 @@ class PsiturkNetworkShell(PsiturkShell):
             print "Hint: In OSX, you can open a terminal link using cmd + click"
             if self.sandbox and use_psiturk_ad_server:
                 print "Note: This sandboxed ad will expire from the server in 16 days."
+
+    def _confirm_dialog(self, prompt):
+        ''' Prompts for a 'yes' or 'no' to given prompt. '''
+        response = raw_input(prompt).strip().lower()
+        valid = {'y': True, 'ye': True, 'yes': True, 'n': False, 'no': False}
+        while True:
+            try:
+                return valid[response]
+            except:
+                response = raw_input("Please respond 'y' or 'n': ").strip().lower()
 
     def create_psiturk_ad(self):
         # register with the ad server (psiturk.org/ad/register) using POST


### PR DESCRIPTION
* Implemented dialog confirmation as private method: _confirmDialog
* Asks for confirmation before HIT is created. created if response resolves to 'yes'. if 'no' or 'n', aborts creation of HIT.