### PR TITLE
Db mode column

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -388,7 +388,8 @@ def start_exp():
             ipaddress=worker_ip,
             browser=browser,
             platform=platform,
-            language=language
+            language=language,
+            mode=mode
         )
         part = Participant(**participant_attributes)
         db_session.add(part)

--- a/psiturk/models.py
+++ b/psiturk/models.py
@@ -34,6 +34,7 @@ class Participant(Base):
     endhit = Column(DateTime)
     bonus = Column(Float, default = 0)
     status = Column(Integer, default = 1)
+    mode = Column(String(128))
     if 'postgres://' in config.get('Database Parameters', 'database_url').lower():
         datastring = Column(Text)
     else:


### PR DESCRIPTION
If you use a version of psiturk with this code on a db that was created with an earlier version of the code, you will need to manually create the 'mode' column in your db. If you're still using `sqlite` and if your schema name is still `participants.db` and your table name is still `turkdemo` (those are the default), you can run this from the terminal:

```
sqlite3 participants.db
ALTER TABLE turkdemo ADD COLUMN mode VARCHAR(128);
<ctrl+d>
```

That same sql will work for mysql and psql, too.