### PR TITLE
Approving, bonusing, and server improvements

### DIFF
--- a/doc/config/hit_configuration.rst
+++ b/doc/config/hit_configuration.rst
@@ -19,7 +19,7 @@ like this:
 	psiturk_keywords = stroop
 	organization_name = New Great University
 	browser_exclude_rule = MSIE, mobile, tablet
-    allow_repeats = false
+	allow_repeats = false
 
 
 `title` [string]

--- a/doc/config/shell_parameters.rst
+++ b/doc/config/shell_parameters.rst
@@ -8,6 +8,9 @@ the psiturk shell.
 
 	[Shell Parameters]
 	launch_in_sandbox_mode = true
+	bonus_message = "Thanks for participating!"
+	use_psiturk_ad_server = true
+	ad_location = false
 
 `launch_in_sandbox_mode` [ true | false]
 -----------------------------------------
@@ -20,6 +23,14 @@ to `true` to lessen the chance of accidentally posting a live HIT to mTurk.
 
    `Overview of the command-line interface <../command_line_overview.html>`__
    	  The basic features of the **psiTurk** command line.
+
+`bonus_message` [string]
+-------------------------
+
+If set to a string, automatically uses this string as the message to
+participants when bonusing them for an assignment. If not set, you will be
+prompted to type in a message each time you bonus participants. (This message is
+required by AMT.)
       
 `use_psiturk_ad_server` [true | false]
 ---------------------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -102,6 +102,8 @@ project:
     secret_key = 'this is my secret key which is hard to guess, i should change this'    
     #certfile = <path_to.crt> 
     #keyfile = <path_to.key>
+    #adserver_revproxy_host = www.location.of.your.revproxy.sans.protocol.com
+    #adserver_revproxy_port = 80 # defaults to 80
 
     [Task Parameters]
     experiment_code_version = 1.0
@@ -110,8 +112,10 @@ project:
 
     [Shell Parameters]
     launch_in_sandbox_mode = true
+    #bonus_message = "Thanks for participating!"
     use_psiturk_ad_server = true
     ad_location = false
+
 
 
 This file is divided into a few sections which are

--- a/psiturk/default_configs/local_config_defaults.txt
+++ b/psiturk/default_configs/local_config_defaults.txt
@@ -39,6 +39,7 @@ num_counters = 1
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
+#bonus_message = "Thanks for participating!"
 
 # If you are not using the psiturk ad server, set `use_psiturk_ad_server` to `false` and point `ad_location` to your proxy server <host> and <port>. Format the ad_location like this:
 #

--- a/psiturk/experiment_server.py
+++ b/psiturk/experiment_server.py
@@ -4,6 +4,7 @@ from gunicorn import util
 import multiprocessing
 from psiturk_config import PsiturkConfig
 import os
+import hashlib
 
 config = PsiturkConfig()
 config.load_config()
@@ -64,6 +65,8 @@ class ExperimentServer(Application):
             print 'Caught ^C, experiment server has shut down.'
             print 'Press `enter` to continue.'
 
+        # add unique identifier of this psiturk project folder
+        project_hash = hashlib.sha1(os.getcwd()).hexdigest()[:12]
         self.user_options = {
             'bind': config.get("Server Parameters", "host") + ":" + config.get("Server Parameters", "port"),
             'workers': workers,
@@ -71,7 +74,7 @@ class ExperimentServer(Application):
             'loglevel': self.loglevels[config.getint("Server Parameters", "loglevel")],
             # 'accesslog': config.get("Server Parameters", "logfile"),
             'errorlog': config.get("Server Parameters", "logfile"),
-            'proc_name': 'psiturk_experiment_server',
+            'proc_name': 'psiturk_experiment_server_' + project_hash,
             'limit_request_line': '0',
             'on_exit': on_exit
         }

--- a/psiturk/experiment_server_controller.py
+++ b/psiturk/experiment_server_controller.py
@@ -8,6 +8,7 @@ import urllib2
 import socket
 import psutil
 import time
+import hashlib
 
 
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -136,7 +137,9 @@ class ExperimentServerController:
                 pid.send_signal(signal.SIGTERM)
 
     def is_server_running(self):
-        PROCNAME = "psiturk_experiment_server"
+        project_hash = hashlib.sha1(os.getcwd()).hexdigest()[:12]
+        # find server processes run by this user from this folder
+        PROCNAME = "psiturk_experiment_server_" + project_hash
         cmd = "ps -o pid,command | grep '"+ PROCNAME + "' | grep -v grep | awk '{print $1}'"
         psiturk_exp_processes = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         output = psiturk_exp_processes.stdout.readlines()

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -1757,8 +1757,12 @@ class PsiturkNetworkShell(PsiturkShell):
             self.worker_list(arg['--submitted'], arg['--approved'],
                              arg['--rejected'], arg['<hit_id>'])
         elif arg['bonus']:
+            if self.config.has_option('Shell Parameters', 'bonus_message'):
+                bonus_message = self.config.get('Shell Parameters', 'bonus_message')
+            else:
+                bonus_message = ""
             self.worker_bonus(arg['<hit_id>'], arg['--auto'], arg['<amount>'],
-                              "", arg['<assignment_id>'])
+                              bonus_message, arg['<assignment_id>'])
         else:
             self.help_worker()
 

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -695,20 +695,20 @@ class PsiturkNetworkShell(PsiturkShell):
         ''' Approve worker '''
         if chosen_hit:
             workers = self.amt_services.get_workers("Submitted")
-            # assignment_ids = [worker['assignmentId'] for worker in workers if \
-            #                   worker['hitId'] == chosen_hit]
             workers = [worker for worker in workers if worker['hitId'] == chosen_hit]
             print 'approving workers for HIT', chosen_hit
         else:
             workers = self.amt_services.get_workers("Submitted")
             workers = [worker for worker in workers if worker['assignmentId'] in assignment_ids]
+            if not workers:
+                print "No submissions found for requested assignment ID's"
         for worker in workers:
             assignment_id = worker['assignmentId']
             init_db()
             found_worker = False
             parts = Participant.query.\
                    filter(Participant.assignmentid == assignment_id).\
-                   filter(Participant.status == 4).\
+                   filter(Participant.status.in_([3, 4])).\
                    all()
             # Iterate through all the people who completed this assignment.
             # This should be one person, and it should match the person who
@@ -735,7 +735,7 @@ class PsiturkNetworkShell(PsiturkShell):
                         print '*** failed to approve worker', part.workerid, 'for assignment', assignment_id
                 # otherwise don't approve, and print warning
                 else:
-                    print 'worker', worker['workerId'], 'not found in DB for assignment', assignment_id + '. Consider rejecting.'
+                    print 'worker', worker['workerId'], 'not found in DB for assignment', assignment_id + '. Not automatically approved.'
             db_session.commit()
 
     def worker_reject(self, chosen_hit, assignment_ids = None):


### PR DESCRIPTION
This branch contains several small features and improvements:

1. **Automatic bonus message**: adds a config option to write a bonus message that will be used whenever bonusing, so the psiturk user doesn't have to keep typing it. I chose "Thanks for participating!" as a default.

2. **Handling missing or duplicate submissions**: I sometimes encounter cases where I have 2 workers with status 4 for a single assignment. Often I get a message from one of the workers saying the MTurk signed them out automatically, or something of that sort. Ideally psiTurk would never set status to 4 without the HIT being sucessfully completed but as a quick fix I added code to make sure that if there are 2 submissions for an assignment, psiTurk checks which one is the true submission with mTurk and gives approval and bonuses properly. I also added code to make sure that when psiTurk is approving all assignments for a HIT, it **DOES NOT** automatically approve a participant if they are not present in the database, as this might mean they didn't really do the HIT.

3. **Allow multiple servers per user**: psiTurk now adds a hash of the current experiment directory to the server process name when starting the server. This allows the server to later be identified and distinguished from other psiTurk servers started by the user, allowing multiple servers to run simultaneously (as long as they're on different ports). (There is an old abandoned pull request (#198) regarding this issue, but I believe that solution could falsely tell the user their server is running when a different psiTurk server is using the same port.)

All three of these improvements have been tested by me on live HITs, though more testing is of course appreciated!