### PR TITLE
Change to Amazon MTurk HIT search URL

### DIFF
--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -1121,9 +1121,11 @@ class PsiturkNetworkShell(PsiturkShell):
             if self.sandbox:
                 mturk_url_base = 'https://workersandbox.mturk.com'
             else:
-                mturk_url_base = 'https://www.mturk.com'
-            mturk_url = '{}/mturk/searchbar?selectedSearchType=hitgroups&searchWords={}'.format(
-                mturk_url_base, urllib.quote_plus(str(self.config.get('HIT Configuration', 'title'))) )
+                mturk_url_base = 'https://worker.mturk.com'
+            mturk_url = '{}/projects?filters%5Bsearch_term%5D={}'.format(
+                mturk_url_base,
+                urllib.quote_plus(
+                    str(self.config.get('HIT Configuration', 'title'))))
 
             print('  MTurk URL: {}'.format(mturk_url) )
             print "Hint: In OSX, you can open a terminal link using cmd + click"


### PR DESCRIPTION
Amazon has recently updated its worker interface. Among these changes is a change in the URL structure when searching for HITs:

e.g. OLD: https://www.mturk.com/mturk/searchbar?selectedSearchType=hitgroups&searchWords=SearchTerm1+SearchTerm2+SearchTerm3
     NEW: https://worker.mturk.com/projects?filters[search_term]=SearchTerm1+SearchTerm2+SearchTerm3

This commit simply reformts the url being rendered to the psiturk user.