### PR TITLE
bf: reference to tally_hits should be update_hit_tally

### DIFF
--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -838,7 +838,7 @@ class PsiturkNetworkShell(PsiturkShell):
     def do_status(self, arg): # overloads do_status with AMT info
         super(PsiturkNetworkShell, self).do_status(arg)
         # server_status = self.server.is_server_running()  # Not used
-        self.tally_hits()
+        self.update_hit_tally()
         if self.sandbox:
             print 'AMT worker site - ' + colorize('sandbox', 'bold') + ': ' \
             + str(self.sandbox_hits) + ' HITs available'


### PR DESCRIPTION
Status command is broken - looks like tally_hits was moved out of the class and a reference to it didn't get fixed.

Updated it to call update_hit_tally instead, seems to be working fine.