### PR TITLE
Get rid of the mysql-python dependency

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -218,7 +218,7 @@ be done at any time), further packages are needed.  On a Debian system, they are
 
 ::
 
-    aptitude install python-mysqldb python-mysqldb-dbg python-sqlalchemy libmysqlclient-dev
+    aptitude install python-pymysql python-sqlalchemy libmysqlclient-dev
 
 If you have additional specific issues, or if you can report the steps
 needed to install psiTurk on a particular Linux distribution, please help

--- a/doc/retrieving.rst
+++ b/doc/retrieving.rst
@@ -20,7 +20,9 @@ While the ``download_datafiles`` shell command is the simplest way to retrieve
 experiment data, a more powerful and flexible solution is to retrieve the data
 programmatically. Many languages offer libraries for interfacing with mysql and
 sqlite databases - below is an example using python and the sqlalchemy package
-to retrieve data from a mysql database. By including code such as this at the
+to retrieve data from a mysql database. We add `+pymysql` to the `db_url` to let
+sqlalchemy make use of pymysql package. (You can leave the database_url in config.txt
+as `mysql://` though -- psiturk adds `+pymysql` internally). By including code such as this at the
 beginning of your analysis script, you can be sure the the data you're analyzing is
 always complete and up-to-date.
 
@@ -30,7 +32,7 @@ always complete and up-to-date.
    import json
    import pandas as pd
 
-   db_url = "mysql://username:password@host.org/database_name"
+   db_url = "mysql+pymysql://username:password@host.org/database_name"
    table_name = 'my_experiment_table'
    data_column_name = 'datastring'
    # boilerplace sqlalchemy setup

--- a/psiturk/amt_services_wrapper.py
+++ b/psiturk/amt_services_wrapper.py
@@ -728,7 +728,7 @@ class MTurkServicesWrapper():
                 # Using regular SQL commands list available database on this
                 # node
                 try:
-                    db_url = 'mysql://' + myinstance.master_username + ":" \
+                    db_url = 'mysql+pymysql://' + myinstance.master_username + ":" \
                         + password + "@" + myinstance.endpoint[0] + ":" + \
                         str(myinstance.endpoint[1])
                     engine = sa.create_engine(db_url, echo=False)
@@ -777,7 +777,7 @@ class MTurkServicesWrapper():
                         print("*** Error creating database %s on instance " \
                               "%s" % (db_name, instance_id))
                         return
-                base_url = 'mysql://' + myinstance.master_username + ":" + \
+                base_url = 'mysql+pymysql://' + myinstance.master_username + ":" + \
                     password + "@" + myinstance.endpoint[0] + ":" + \
                     str(myinstance.endpoint[1]) + "/" + db_name
                 self.config.set("Database Parameters", "database_url", base_url)

--- a/psiturk/db.py
+++ b/psiturk/db.py
@@ -15,14 +15,7 @@ else:
     DATABASE = config.get('Database Parameters', 'database_url')
 
 if 'mysql' in config.get('Database Parameters', 'database_url').lower():
-	try:
-		 __import__('imp').find_module('pymysql')
-	except ImportError:
-		print("Sorry, to use a MySQL database you need to install "
-			  "the `mysql-python` python package.  Try `pip install "
-			  "mysql-python`. Hopefully it goes smoothly for you. "
-			  "Installation can be tricky on some systems.")
-		exit()
+	DATABASE = DATABASE[:5] + '+pymysql' + DATABASE[5:]
 
 engine = create_engine(DATABASE, echo=False, pool_recycle=3600) 
 db_session = scoped_session(sessionmaker(autocommit=False,

--- a/psiturk/db.py
+++ b/psiturk/db.py
@@ -14,15 +14,17 @@ if matches:
 else:
     DATABASE = config.get('Database Parameters', 'database_url')
 
-if 'mysql' in config.get('Database Parameters', 'database_url').lower():
+if 'mysql://' in DATABASE.lower():
 	try:
 		 __import__('imp').find_module('pymysql')
 	except ImportError:
-		print("Sorry, to use a MySQL database you need to install "
-			  "the `mysql-python` python package.  Try `pip install "
-			  "mysql-python`. Hopefully it goes smoothly for you. "
-			  "Installation can be tricky on some systems.")
+		print("To use a MySQL database you need to install "
+			  "the `pymysql` python package.  Try `pip install "
+			  "pymysql`.")
 		exit()
+	# internally use `mysql+pymysql://` so sqlalchemy talks to
+	# the pymysql package
+	DATABASE = DATABASE.replace('mysql://', 'mysql+pymysql://')
 
 engine = create_engine(DATABASE, echo=False, pool_recycle=3600) 
 db_session = scoped_session(sessionmaker(autocommit=False,

--- a/psiturk/db.py
+++ b/psiturk/db.py
@@ -16,7 +16,7 @@ else:
 
 if 'mysql' in config.get('Database Parameters', 'database_url').lower():
 	try:
-		 __import__('imp').find_module('MySQLdb')
+		 __import__('imp').find_module('pymysql')
 	except ImportError:
 		print("Sorry, to use a MySQL database you need to install "
 			  "the `mysql-python` python package.  Try `pip install "

--- a/psiturk/db.py
+++ b/psiturk/db.py
@@ -15,7 +15,14 @@ else:
     DATABASE = config.get('Database Parameters', 'database_url')
 
 if 'mysql' in config.get('Database Parameters', 'database_url').lower():
-	DATABASE = DATABASE[:5] + '+pymysql' + DATABASE[5:]
+	try:
+		 __import__('imp').find_module('pymysql')
+	except ImportError:
+		print("Sorry, to use a MySQL database you need to install "
+			  "the `mysql-python` python package.  Try `pip install "
+			  "mysql-python`. Hopefully it goes smoothly for you. "
+			  "Installation can be tricky on some systems.")
+		exit()
 
 engine = create_engine(DATABASE, echo=False, pool_recycle=3600) 
 db_session = scoped_session(sessionmaker(autocommit=False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 Flask==0.12.2
-SQLAlchemy==0.8.3
+SQLAlchemy==1.1.18
 gunicorn==19.4.5
 boto==2.15.0
 cmd2==0.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 argparse==1.2.1
 Flask==0.12.2
 SQLAlchemy==1.1.18
+pymysql==0.9.0
 gunicorn==19.4.5
 boto==2.15.0
 cmd2==0.6.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 argparse==1.2.1
 Flask==0.12.2
 SQLAlchemy==1.1.18
-pymysql==0.9.0
 gunicorn==19.4.5
 boto==2.15.0
 cmd2==0.6.7


### PR DESCRIPTION
Until now, it was necessary to manually install the `mysql-python` package if one wanted to save the data in a [MySQL database](https://psiturk.readthedocs.io/en/latest/configure_databases.html?highlight=sql#using-a-self-hosted-mysql-database-recommended). Unfortunately, getting `mysql-python` properly installed was a nightmare. And `mysql-python` has hasn't been updated since 2014.

`pymysql` is a pure python alternative, which is [actively maintained](https://github.com/PyMySQL/PyMySQL) and which can be installed without problems. With `pymysql`, psiturk and your MySQL database can be happy again.

(Fixes #97)