### PR TITLE
later SQAlchamy is compatible with mysql 8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argparse==1.2.1
 Flask==0.12.2
-SQLAlchemy==1.1.18
+SQLAlchemy>=1.1.18
 gunicorn==19.4.5
 boto==2.15.0
 cmd2==0.6.7


### PR DESCRIPTION
Passed test at 9806225fa3a5dbb2c64c86bc42067a77462f9d72 with `mysql --version
mysql  Ver 8.0.12 for osx10.14 on x86_64 (Homebrew)` and `SQAlchemy 1.2.15`.