### PR TITLE
More details in "Creating an AMT Requester account"

### DIFF
--- a/doc/amt_setup.rst
+++ b/doc/amt_setup.rst
@@ -89,7 +89,7 @@ Creating an AMT Requester account
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To use your AWS keys to interface with Amazon Mechanical Turk, you need to create a requester account.
-Please see `Amazon's instructions <http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMechanicalTurkGettingStartedGuide/SetUp.html>`__ for this.  In particular, it is necessary to at least once login to the requester site (`http://requester.mturk.com <http://requester.mturk.com>`__) and also to at least once login to the sandbox requester site (`https://requestersandbox.mturk.com <https://requestersandbox.mturk.com>`__), so that you can agree to the terms of service.
+Please see `Amazon's instructions <http://docs.aws.amazon.com/AWSMechTurk/latest/AWSMechanicalTurkGettingStartedGuide/SetUp.html>`__ for this.  In particular, it is necessary to at least once login to the requester site (`http://requester.mturk.com <http://requester.mturk.com>`__) and also to at least once login to the sandbox requester site (`https://requestersandbox.mturk.com <https://requestersandbox.mturk.com>`__), so that you can agree to the terms of service. You will also need to to link your AWS Account to both requester and sandbox requester account, you can do that by clicking on the developer tab once logged in the sites, and following instructions therein.
 
 
 Linking funds


### PR DESCRIPTION
Related to issue discussed in #370.

Added a sentence in the documentation for being careful to link both requester and sandbox requester account to AWS account.