### PR TITLE
Quickstart documentation update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cffi==1.12.3
 chardet==3.0.4
 ciso8601==2.1.1
 Click==7.0
-cmd2==0.9.16
+cmd2==0.9.13
 colorama==0.4.1
 configparser==3.7.4
 contextlib2==0.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cffi==1.12.3
 chardet==3.0.4
 ciso8601==2.1.1
 Click==7.0
-cmd2==0.9.14
+cmd2==0.9.16
 colorama==0.4.1
 configparser==3.7.4
 contextlib2==0.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cffi==1.12.3
 chardet==3.0.4
 ciso8601==2.1.1
 Click==7.0
-cmd2==0.9.13
+cmd2==0.9.14
 colorama==0.4.1
 configparser==3.7.4
 contextlib2==0.5.5


### PR DESCRIPTION
First, I updated the requirement from Python 2.7 or lower to Python 3.0 or higher (since that's required now, right?). I don't know if there are restrictions on which Python 3 versions that can be used though.

I also added instructions of how to install a release since this was something that wasn't specified in the readme already.