### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/psiturk/amt_services_wrapper.py
+++ b/psiturk/amt_services_wrapper.py
@@ -23,7 +23,7 @@ from sqlalchemy import or_, and_
 from sqlalchemy.sql.operators import eq
 import sqlalchemy as sa
 import webbrowser
-from fuzzywuzzy import process
+from rapidfuzz import process
 import signal
 import datetime
 import random

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -24,7 +24,7 @@ import sqlalchemy as sa
 import webbrowser
 from docopt import docopt, DocoptExit
 from cmd2 import Cmd, EmptyStatement
-from fuzzywuzzy import process
+from rapidfuzz import process
 import signal
 import certifi
 import datetime

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ Flask-Login==0.4.1
 Flask-RESTful==0.3.7
 funcsigs==1.0.2
 future==0.17.1
-fuzzywuzzy==0.17.0
 gitdb2==2.0.5
 GitPython==2.1.11
 gunicorn[gevent]==19.9.0
@@ -50,9 +49,9 @@ pytest==4.6.3
 pytest-mock==1.10.4
 python-dateutil==2.8.0
 python-dotenv==0.10.5
-python-Levenshtein==0.12.0
 pytz==2019.1
 PyYAML==5.1.1
+rapidfuzz==0.2.1
 requests==2.22.0
 s3transfer==0.2.1
 scandir==1.10.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy. 