### PR TITLE
🐛 fix #412: jquery path typo, localhost=>127.0.0.1, contact_email_on_error

### DIFF
--- a/psiturk/default_configs/local_config_defaults.txt
+++ b/psiturk/default_configs/local_config_defaults.txt
@@ -7,7 +7,7 @@ us_only = true
 approve_requirement = 95
 number_hits_approved = 0
 require_master_workers = false
-contact_email_on_error = youremail@gmail.com
+contact_email_on_error = 0
 ad_group = Default psiTurk Stroop Example
 psiturk_keywords = stroop
 organization_name = New Great University
@@ -19,7 +19,7 @@ database_url = sqlite:///participants.db
 table_name = turkdemo
 
 [Server Parameters]
-host = localhost
+host = 127.0.0.1
 port = 22362
 cutoff_time = 30
 logfile = server.log

--- a/psiturk/default_configs/local_config_defaults.txt
+++ b/psiturk/default_configs/local_config_defaults.txt
@@ -7,7 +7,7 @@ us_only = true
 approve_requirement = 95
 number_hits_approved = 0
 require_master_workers = false
-contact_email_on_error = 0
+contact_email_on_error = email_address@example.com
 ad_group = Default psiTurk Stroop Example
 psiturk_keywords = stroop
 organization_name = New Great University
@@ -29,7 +29,7 @@ login_username = examplename
 login_pw = examplepassword
 threads = auto
 secret_key = 'this is my secret key which is hard to guess, i should change this'
-#certfile = <path_to.crt> 
+#certfile = <path_to.crt>
 #keyfile = <path_to.key>
 #adserver_revproxy_host = www.location.of.your.revproxy.sans.protocol.com
 #adserver_revproxy_port = 80 # defaults to 80
@@ -47,7 +47,7 @@ persistent_history_file = .psiturk_history
 
 # If you are not using the psiturk ad server, set `use_psiturk_ad_server` to `false` and point `ad_location` to your proxy server <host> and <port>. Format the ad_location like this:
 #
-#   https://<host>:<port>/ad 
+#   https://<host>:<port>/ad
 
 use_psiturk_ad_server = true
 ad_location = false

--- a/psiturk/example/templates/exp.html
+++ b/psiturk/example/templates/exp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- 
+<!--
   The exp.html is the main form that
   controls the experiment.
 
@@ -11,7 +11,7 @@
         <title>Psychology Experiment</title>
         <link rel="icon" href="/static/favicon.ico" />
 
-        <!-- libraries used in your experiment 
+        <!-- libraries used in your experiment
 			psiturk specifically depends on underscore.js, backbone.js and jquery
     	-->
 		<script src="/static/lib/jquery-3.4.1.min.js" type="text/javascript"> </script>
@@ -25,16 +25,16 @@
 			var condition = {{ condition }}; // the condition number
 			var counterbalance = {{ counterbalance }}; // a number indexing counterbalancing conditions
 			var codeversion = {{ codeversion }}; // a number indexing counterbalancing conditions
-			var contact_address = {{ contact_address }}; // a number indexing counterbalancing conditions
+			var contact_address = "{{ contact_address }}"; // a number indexing counterbalancing conditions
 			var adServerLoc = "{{ adServerLoc }}"; // the location of your ad (so you can send user back at end of experiment)
 			var mode = "{{ mode }}";
 		</script>
-				
+
 		<!-- utils.js and psiturk.js provide the basic psiturk functionality -->
 		<script src="/static/js/utils.js" type="text/javascript"> </script>
 		<script src="/static/js/psiturk.js" type="text/javascript"> </script>
 
-		<!-- task.js is where you experiment code actually lives 
+		<!-- task.js is where you experiment code actually lives
 			for most purposes this is where you want to focus debugging, development, etc...
 		-->
 		<script src="/static/js/task.js" type="text/javascript"> </script>
@@ -46,9 +46,8 @@
 	    <noscript>
 			<h1>Warning: Javascript seems to be disabled</h1>
 			<p>This website requires that Javascript be enabled on your browser.</p>
-			<p>Instructions for enabling Javascript in your browser can be found 
+			<p>Instructions for enabling Javascript in your browser can be found
 			<a href="http://support.google.com/bin/answer.py?hl=en&answer=23852">here</a></p>
 		</noscript>
     </body>
 </html>
-

--- a/psiturk/example/templates/exp.html
+++ b/psiturk/example/templates/exp.html
@@ -14,7 +14,7 @@
         <!-- libraries used in your experiment 
 			psiturk specifically depends on underscore.js, backbone.js and jquery
     	-->
-		<script src="/static/lib/jquery-3.4.1min.js" type="text/javascript"> </script>
+		<script src="/static/lib/jquery-3.4.1.min.js" type="text/javascript"> </script>
 		<script src="/static/lib/underscore-min.js" type="text/javascript"> </script>
 		<script src="/static/lib/backbone-min.js" type="text/javascript"> </script>
 		<script src="/static/lib/d3.v3.min.js" type="text/javascript"> </script>


### PR DESCRIPTION
I didn't follow `contact_email_on_error` to see if you should be a quoted address or is a boolean flag. This is just a quick fix so the example will run in a browser.