### PR TITLE
Fixes example

### DIFF
--- a/psiturk/example/templates/exp.html
+++ b/psiturk/example/templates/exp.html
@@ -24,8 +24,8 @@
 			var uniqueId = "{{ uniqueId }}";  // a unique string identifying the worker/task
 			var condition = {{ condition }}; // the condition number
 			var counterbalance = {{ counterbalance }}; // a number indexing counterbalancing conditions
-			var codeversion = {{ codeversion }}; // a number indexing counterbalancing conditions
-			var contact_address = "{{ contact_address }}"; // a number indexing counterbalancing conditions
+			var codeversion = "{{ codeversion }}"; // a string representing the current experiment version
+			var contact_address = "{{ contact_address }}"; // your email address
 			var adServerLoc = "{{ adServerLoc }}"; // the location of your ad (so you can send user back at end of experiment)
 			var mode = "{{ mode }}";
 		</script>


### PR DESCRIPTION
This patch adds quotation marks around codeversion to ensure that it is properly interpreted as a string and updates the comments to remove duplication of 'a number indexing counterbalancing conditions.'