### PR TITLE
standardize on require_quals and block_quals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.1
+### Fixed & Changed
+- fixed an inconsistency between shell usage of "allowlist-qualification-ids" and
+  and config file calling the same "require_quals", same for "blocklist" and "block_quals". Also, documentation incorrectly described the config file accepting "allowlist_qualification_ids", while it only actually accepted "require_quals." Standardized on "require" and "block" throughout. Maintained backwards compatibility except in shell usage since docopt
+  doesn't seem to allow it in the way it parses the usage string, but no way
+  am I going to bump to 4.0.0 just because of that!
 
 ## 3.0.0
 ### Changed

--- a/doc/settings.rst
+++ b/doc/settings.rst
@@ -209,10 +209,10 @@ Note that this option does not affect the behavior when a participant starts
 the experiment but the quits or refreshes the page. In those cases, they will
 still be locked out, regardless of the setting of `allow_repeats`.
 
-.. _whitelist_qualification_ids:
+.. _require_quals:
 
-whitelist_qualification_ids
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+require_quals
+~~~~~~~~~~~~~
 
 A list of custom qualifications that participants must possess to
 perform your task.
@@ -223,7 +223,7 @@ You may need to ensure that workers have some requisite skill or pass some
 previous screening factors, such as language proficiency or having already
 completed one of your tasks.  AMT uses custom qualification types to perform
 this filtering. When you add a custom qualification to
-`whitelist_qualification_ids`, AMT will only show your ad to potential
+``require_quals``, AMT will only show your ad to potential
 participants who already have that qualification set.  Other MTurk workers will
 neither see your ad nor be able to accept the HIT.
 
@@ -233,17 +233,17 @@ and `Best practices for managing workers in follow-up surveys <https://blog.mtur
 for additional details on custom qualifications.
 
 
-.. _blacklist_qualification_ids:
+.. _block_quals:
 
-blacklist_qualification_ids
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+block_quals
+~~~~~~~~~~~
 
 A list of custom qualifications that participants must not possess to
 perform your task.
 
 :Type: comma-delimited ``string``
 
-When you add a custom qualification to `blacklist_qualification_ids`, MTurk
+When you add a custom qualification to ``block_quals``, MTurk
 workers with that qualification already set will neither see your ad nor be able
 to accept your HIT. This is the recommended way of excluding participants who
 have performed other HITs for you from participating in your new HIT.

--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -318,11 +318,11 @@ class MTurkServices(object):
                 LocaleValues=[{'Country': 'US'}]
             ))
 
-        for qual_id in hit_config['whitelist_qualification_ids']:
+        for qual_id in hit_config['require_qualification_ids']:
             quals.append(dict(QualificationTypeId=qual_id,
                               Comparator='Exists'))
 
-        for qual_id in hit_config['blacklist_qualification_ids']:
+        for qual_id in hit_config['block_qualification_ids']:
             quals.append(dict(QualificationTypeId=qual_id,
                               Comparator='DoesNotExist'))
 

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -368,12 +368,18 @@ class PsiturkNetworkShell(Cmd, object):
                 response = input("Please respond 'y' or 'n': ").strip().lower()
 
     def hit_create(self, num_workers, reward, duration,
-                   whitelist_qualification_ids=None, blacklist_qualification_ids=None):
+                   require_qualification_ids=None, block_qualification_ids=None, **kwargs):
 
-        if whitelist_qualification_ids is None:
-            whitelist_qualification_ids = []
-        if blacklist_qualification_ids is None:
-            blacklist_qualification_ids = []
+        # backwards compatibility
+        if 'whitelist_qualification_ids' in kwargs and not require_qualification_ids:
+            require_qualification_ids = kwargs['whitelist_qualification_ids']
+        if 'blacklist_qualification_ids' in kwargs and not block_qualification_ids:
+            block_qualification_ids = kwargs['blacklist_qualification_ids']
+
+        if require_qualification_ids is None:
+            require_qualification_ids = []
+        if block_qualification_ids is None:
+            block_qualification_ids = []
 
         # Argument retrieval and validation
         if num_workers is None:
@@ -430,8 +436,8 @@ class PsiturkNetworkShell(Cmd, object):
         try:
             create_hit_response = self.amt_services_wrapper.create_hit(num_workers=num_workers, reward=reward,
                                                                        duration=duration,
-                                                                       whitelist_qualification_ids=whitelist_qualification_ids,
-                                                                       blacklist_qualification_ids=blacklist_qualification_ids)
+                                                                       require_qualification_ids=require_qualification_ids,
+                                                                       block_qualification_ids=block_qualification_ids)
 
             if create_hit_response.status != 'success':
                 self.poutput('Error during hit creation.')
@@ -721,7 +727,7 @@ class PsiturkNetworkShell(Cmd, object):
     def do_hit(self, arg):
         """
         Usage:
-          hit create [<num_workers> <reward> <duration>] [--whitelist-qualification-id <whitelist_qualification_id>]... [--blacklist-qualification-id <blacklist_qualification_id>]...
+          hit create [<num_workers> <reward> <duration>] [--require-qualification-id <require_qualification_id>]... [--block-qualification-id <block_qualification_id>]...
           hit extend <HITid> [(--assignments <number>)] [(--expiration <minutes>)]
           hit expire (--all | <HITid> ...)
           hit delete (--all | <HITid> ...) [--all-studies]
@@ -733,8 +739,8 @@ class PsiturkNetworkShell(Cmd, object):
 
         if arg['create']:
             self.hit_create(arg['<num_workers>'], arg['<reward>'], arg['<duration>'],
-                            whitelist_qualification_ids=arg['<whitelist_qualification_id>'],
-                            blacklist_qualification_ids=arg['<blacklist_qualification_id>'])
+                            require_qualification_ids=arg['<require_qualification_id>'],
+                            block_qualification_ids=arg['<block_qualification_id>'])
         elif arg['extend']:
             result = self.amt_services_wrapper.extend_hit(
                 arg['<HITid>'][0], assignments=arg['<number>'], minutes=arg['<minutes>'])

--- a/psiturk/version.py
+++ b/psiturk/version.py
@@ -1,1 +1,1 @@
-version_number = '3.0.0'
+version_number = '3.0.1'

--- a/tests/test_amt.py
+++ b/tests/test_amt.py
@@ -46,16 +46,16 @@ class TestAmtServices(object):
         # confirm that it's in the local db...
         assert Hit.query.get('ABCDUITW8URHJMX7F00H20LGRIAQTX') is not None
 
-    def test_wrapper_hit_create_with_whitelist_qualification(self, stubber, amt_services_wrapper):
+    def test_wrapper_hit_create_with_require_qualification(self, stubber, amt_services_wrapper):
         """
-        makes sure that whitelist_qualid finds its way into the qual list as EXISTS
+        makes sure that require_qualid finds its way into the qual list as EXISTS
         """
 
-        WHITELIST_QUAL_ID = 'WHITELISTQUAL_123'
+        REQUIRE_QUAL_ID = 'REQUIREQUAL_123'
         quals = psiturk_standard_quals + [
             {
                 'Comparator': 'Exists',
-                'QualificationTypeId': WHITELIST_QUAL_ID
+                'QualificationTypeId': REQUIRE_QUAL_ID
             }]
 
         stubber.add_response('create_hit_type', {'HITTypeId': 'HITTypeId_123'}, {
@@ -73,22 +73,22 @@ class TestAmtServices(object):
         })
         # import pytest; pytest.set_trace()
         response = amt_services_wrapper.create_hit(1, 0.01, 1,
-                                                   whitelist_qualification_ids=[WHITELIST_QUAL_ID])
+                                                   require_qualification_ids=[REQUIRE_QUAL_ID])
         if not response.success:
             raise response.exception
 
-    def test_wrapper_hit_create_with_multiple_whitelist_qualifications(self, stubber,
+    def test_wrapper_hit_create_with_multiple_require_qualifications(self, stubber,
                                                                        amt_services_wrapper):
         """
-        makes sure that whitelist_qualid finds its way into the qual list as EXISTS
+        makes sure that require_qualid finds its way into the qual list as EXISTS
         """
 
-        WHITELIST_QUAL_IDS = 'WHITELISTQUAL_123, WHITELISTQUAL_123'
+        REQUIRE_QUAL_IDS = 'REQUIREQUAL_123, REQUIREQUAL_123'
         quals = psiturk_standard_quals + [
             {
                 'Comparator': 'Exists',
                 'QualificationTypeId': qual_id
-            } for qual_id in WHITELIST_QUAL_IDS]
+            } for qual_id in REQUIRE_QUAL_IDS]
 
         stubber.add_response('create_hit_type', {'HITTypeId': 'HITTypeId_123'}, {
             'Title': ANY,
@@ -105,7 +105,7 @@ class TestAmtServices(object):
         })
         # import pytest; pytest.set_trace()
         response = amt_services_wrapper.create_hit(1, 0.01, 1,
-                                                   whitelist_qualification_ids=WHITELIST_QUAL_IDS)
+                                                   require_qualification_ids=REQUIRE_QUAL_IDS)
         if not response.success:
             raise response.exception
 
@@ -114,21 +114,21 @@ class TestAmtServices(object):
                                                                                stubber,
                                                                                amt_services_wrapper):
         """
-        makes sure that whitelist_qualid finds its way into the qual list as EXISTS
+        makes sure that require_qualid finds its way into the qual list as EXISTS
         """
 
-        whitelist_config_file_qual_ids = ['whitelist_config_123', 'whitelist_config_456']
-        blacklist_config_file_qual_ids = ['blacklist_config_123', 'blacklist_config_456']
+        require_config_file_qual_ids = ['require_config_123', 'require_config_456']
+        block_config_file_qual_ids = ['block_config_123', 'block_config_456']
 
         edit_config_file(';require_quals =',
                          'require_quals = {}'.format(
-                             ','.join(whitelist_config_file_qual_ids)))
+                             ','.join(require_config_file_qual_ids)))
         edit_config_file(';block_quals =',
                          'block_quals = {}'.format(
-                             ','.join(blacklist_config_file_qual_ids)))
+                             ','.join(block_config_file_qual_ids)))
 
-        whitelist_qualification_ids_passed = ['white_passed_123', 'white_passed_456']
-        blacklist_qualification_ids_passed = ['black_passed_123', 'black_passed_456']
+        require_qualification_ids_passed = ['white_passed_123', 'white_passed_456']
+        block_qualification_ids_passed = ['black_passed_123', 'black_passed_456']
 
         # need to reset the amt_services_wrapper config after editing config file above.
         from psiturk.psiturk_config import PsiturkConfig
@@ -138,28 +138,28 @@ class TestAmtServices(object):
 
         hit_config = amt_services_wrapper._generate_hit_config(
             'loc_123', 1, '1.00', 1,
-            whitelist_qualification_ids=whitelist_qualification_ids_passed,
-            blacklist_qualification_ids=blacklist_qualification_ids_passed)
+            require_qualification_ids=require_qualification_ids_passed,
+            block_qualification_ids=block_qualification_ids_passed)
 
-        whitelist_qual_ids = whitelist_config_file_qual_ids + whitelist_qualification_ids_passed
-        blacklist_qual_ids = blacklist_config_file_qual_ids + blacklist_qualification_ids_passed
+        require_qual_ids = require_config_file_qual_ids + require_qualification_ids_passed
+        block_qual_ids = block_config_file_qual_ids + block_qualification_ids_passed
 
-        for qual in whitelist_qual_ids:
-            assert qual in hit_config['whitelist_qualification_ids']
+        for qual in require_qual_ids:
+            assert qual in hit_config['require_qualification_ids']
 
-        for qual in blacklist_qual_ids:
-            assert qual in hit_config['blacklist_qualification_ids']
+        for qual in block_qual_ids:
+            assert qual in hit_config['block_qualification_ids']
 
-    def test_wrapper_hit_create_with_blacklist_qualification(self, stubber, amt_services_wrapper):
+    def test_wrapper_hit_create_with_block_qualification(self, stubber, amt_services_wrapper):
         """
-        makes sure that whitelist_qualid finds its way into the qual list as EXISTS
+        makes sure that require_qualid finds its way into the qual list as EXISTS
         """
 
-        BLACKLIST_QUAL_ID = 'QUAL_123'
+        BLOCK_QUAL_ID = 'QUAL_123'
         quals = psiturk_standard_quals + [
             {
                 'Comparator': 'DoesNotExist',
-                'QualificationTypeId': BLACKLIST_QUAL_ID
+                'QualificationTypeId': BLOCK_QUAL_ID
             }]
 
         stubber.add_response('create_hit_type', {'HITTypeId': 'HITTypeId_123'}, {
@@ -177,26 +177,26 @@ class TestAmtServices(object):
         })
         # import pytest; pytest.set_trace()
         response = amt_services_wrapper.create_hit(1, 0.01, 1,
-                                                   blacklist_qualification_ids=[BLACKLIST_QUAL_ID])
+                                                   block_qualification_ids=[BLOCK_QUAL_ID])
         if not response.success:
             raise response.exception
 
-    def test_wrapper_hit_create_with_whitelist_and_blacklist_qualifications(self, stubber,
+    def test_wrapper_hit_create_with_require_and_block_qualifications(self, stubber,
                                                                             amt_services_wrapper):
         """
-        makes sure that whitelist_qualid finds its way into the qual list as EXISTS
+        makes sure that require_qualid finds its way into the qual list as EXISTS
         """
 
-        WHITELIST_QUAL_ID = 'WHITELISTQUAL_123'
-        BLACKLIST_QUAL_ID = 'BLACKLISTQUAL_123'
+        REQUIRE_QUAL_ID = 'REQUIREQUAL_123'
+        BLOCK_QUAL_ID = 'BLOCKQUAL_123'
         quals = psiturk_standard_quals + [
             {
                 'Comparator': 'Exists',
-                'QualificationTypeId': WHITELIST_QUAL_ID
+                'QualificationTypeId': REQUIRE_QUAL_ID
             },
             {
                 'Comparator': 'DoesNotExist',
-                'QualificationTypeId': BLACKLIST_QUAL_ID
+                'QualificationTypeId': BLOCK_QUAL_ID
             }]
 
         stubber.add_response('create_hit_type', {'HITTypeId': 'HITTypeId_123'}, {
@@ -214,8 +214,8 @@ class TestAmtServices(object):
         })
         # import pytest; pytest.set_trace()
         response = amt_services_wrapper.create_hit(1, 0.01, 1,
-                                                   whitelist_qualification_ids=[WHITELIST_QUAL_ID],
-                                                   blacklist_qualification_ids=[BLACKLIST_QUAL_ID])
+                                                   require_qualification_ids=[REQUIRE_QUAL_ID],
+                                                   block_qualification_ids=[BLOCK_QUAL_ID])
         if not response.success:
             raise response.exception
 

--- a/tests/test_psiturk_shell.py
+++ b/tests/test_psiturk_shell.py
@@ -91,7 +91,7 @@ commands = [
     (['mode live'], 'mode_live'),
     (['mode live', 'mode sandbox'], 'mode_live_then_sandbox'),
     (['hit create 1 0.01 1'], 'hit_create'),
-    (['hit create 1 0.01 1 --whitelist-qualification-id abc123 --whitelist-qualification-id abc456'],
+    (['hit create 1 0.01 1 --require-qualification-id abc123 --require-qualification-id abc456'],
         'hit_create_with_qualification'),
     (['hit extend ABC --assignments 1 --expiration 1'], 'hit_extend'),
     (['hit expire ABC'], 'hit_expire_hitid'),


### PR DESCRIPTION
fixed an inconsistency between shell usage of "allowlist-qualification-ids" and
and config file calling the same "require_quals", same for "blocklist" and "block_quals". Also, documentation incorrectly described the config file accepting "allowlist_qualification_ids", while it only actually accepted "require_quals." Standardized on "require" and "block" throughout. Maintained backwards compatibility except in shell usage since docopt
doesn't seem to allow it in the way it parses the usage string