### PR TITLE
adds and option on startup to move to a different subfolder

### DIFF
--- a/psiturk/experiment_server.py
+++ b/psiturk/experiment_server.py
@@ -32,10 +32,11 @@ class ExperimentServer(Application):
     Custom Gunicorn Server Application that serves up the Experiment application
     """
 
-    def __init__(self):
+    def __init__(self, app_dir=None):
         """__init__ method
         Load the base config and assign some core attributes.
         """
+
         self.loglevels = ["debug", "info", "warning", "error", "critical"]
         self.load_user_config()
         self.usage = None
@@ -43,6 +44,9 @@ class ExperimentServer(Application):
         self.options = self.user_options
         self.prog = None
         self.do_load_config()
+        if app_dir:
+            self.cfg.set('chdir', app_dir) # get directory
+            self.chdir() # change to it
         self.user_options = {}
         print("Now serving on", "http://" + self.options["bind"])
 
@@ -106,8 +110,8 @@ class ExperimentServer(Application):
                 {'timeout': config.get('Server Parameters', "server_timeout")})
 
 
-def launch():
-    ExperimentServer().run()
+def launch(app_dir=None):
+    ExperimentServer(app_dir).run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
currently the Heroku set up requires all the files to be in the top level folder.  however some times it would be convenient to have multiple experiments in a single github folder and to swap between them.  this adds an option (None by default) to let you configure this.  the tip to use it would be, on Heroku, to change the `heroku_app.py` file so that you pass a directory to `exp.launch()`.  For example, if your experiment was in ./exp1 then `exp.launch("./exp1")`.  the `config.txt` should be placed inside exp1 folder in this instance as well as static, templates and the custom.py file.