### PR TITLE
Fix scoping bug in download_datafiles

### DIFF
--- a/psiturk/models.py
+++ b/psiturk/models.py
@@ -125,8 +125,7 @@ class Participant(Base):
                             event["timestamp"]
                          )
                     )
-
-            return outstring.getvalue()
+                return outstring.getvalue()
         except:
             print(("Error reading record:", self))
             return ""
@@ -150,7 +149,7 @@ class Participant(Base):
                             questiondata[question]
                          )
                     )
-            return outstring.getvalue()
+                return outstring.getvalue()
         except:
             print(("Error reading record:", self))
 


### PR DESCRIPTION
The variable `outstring` defined in a `with` statement is used outside the scope of the `with` in `get_question_data` and `get_event_data`, resulting in question and event data both throwing "Error reading record" errors (the exception being "I/O operation on closed file") when running `download_datafiles` from the psiturk shell.