### PR TITLE
Add custom MTurk qualification support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - user_utils.PsiTurkAuthorization should not allow empty username or password! (#492)
 
+### Added
+- Add custom MTurk qualification support (#493)
+
 ## [3.1.0]
 ### Added
 - ability to launch the experiment server from a subdirectory instead of just

--- a/doc/settings.rst
+++ b/doc/settings.rst
@@ -248,6 +248,22 @@ workers with that qualification already set will neither see your ad nor be able
 to accept your HIT. This is the recommended way of excluding participants who
 have performed other HITs for you from participating in your new HIT.
 
+.. _advanced_quals:
+
+advanced_quals_path
+~~~~~~~~~~~~~~~~~~~
+
+A path to a custom JSON qualifications file, where you can define your own
+MTurk qualification requirements, as seen in `advanced_quals.json.sample`__
+
+__ https://raw.githubusercontent.com/NYUCCL/psiTurk/master/psiturk/example/advanced_quals.json.sample
+
+:type: ``path``
+
+Example::
+
+    advanced_quals_path = ./advanced_quals.json
+
 
 .. _hit_configuration_ad_url:
 

--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -325,6 +325,9 @@ class MTurkServices(object):
         for qual_id in hit_config['block_qualification_ids']:
             quals.append(dict(QualificationTypeId=qual_id,
                               Comparator='DoesNotExist'))
+        
+        for advanced_qual in hit_config['advanced_qualifications']:
+            quals.append(dict(advanced_qual))
 
         # Create a HIT type for this HIT.
         hit_type = self.mtc.create_hit_type(

--- a/psiturk/amt_services_wrapper.py
+++ b/psiturk/amt_services_wrapper.py
@@ -15,6 +15,7 @@ import sqlalchemy as sa
 import datetime
 import random
 import string
+import json
 from builtins import object
 from builtins import range
 from builtins import str
@@ -828,6 +829,18 @@ class MTurkServicesWrapper(object):
         block_quals = self.config.get('HIT Configuration', 'block_quals', fallback=None)
         if block_quals:
             block_qualification_ids.extend(block_quals.split(','))
+        
+        advanced_quals_path = self.config.get('HIT Configuration', 'advanced_quals_path', fallback=None)
+        advanced_qualifications = []
+        if advanced_quals_path:
+            with open(advanced_quals_path) as f:
+                advanced_qualifications = json.load(f)
+                if not isinstance(advanced_qualifications, list):
+                    raise PsiturkException(message=f'JSON file "{advanced_quals_path}" must be a list of dicts')
+                else:
+                    for el in advanced_qualifications:
+                        if not isinstance(el, dict):
+                            raise PsiturkException(message=f'JSON file "{advanced_quals_path}" must be a list of dicts')
 
         hit_config = {
             "ad_location": ad_url,
@@ -845,6 +858,7 @@ class MTurkServicesWrapper(object):
             "require_master_workers": self.config.getboolean('HIT Configuration',
                                                              'require_master_workers'),
             "require_qualification_ids": require_qualification_ids,
-            "block_qualification_ids": block_qualification_ids
+            "block_qualification_ids": block_qualification_ids,
+            "advanced_qualifications": advanced_qualifications
         }
         return hit_config

--- a/psiturk/example/advanced_quals.json.sample
+++ b/psiturk/example/advanced_quals.json.sample
@@ -1,0 +1,11 @@
+[
+    {
+        "QualificationTypeId": "<SOME QUALIFICATION TYPE ID>",
+        "Comparator": "GreaterThan",
+        "IntegerValues": [65]
+    },
+    {
+        "QualificationTypeId": "<SOME QUALIFICATION TYPE ID>",
+        "Comparator": "Exists"
+    }
+]

--- a/psiturk/example/config.txt.sample
+++ b/psiturk/example/config.txt.sample
@@ -52,7 +52,9 @@
 
 # A path to a custom JSON qualifications file, where you can define your own
 # MTurk qualification requirements, as seen in advanced_quals.json.sample
-;advanced_quals_path = ./advanced_quals.json
+# Example:
+#    ;advanced_quals_path = ./advanced_quals.json
+;advanced_quals_path = 
 
 ## Hit Configuration - Ad Url ##################################################
 # Config settings for constructing the task's "landing page"
@@ -78,7 +80,7 @@
 # you may uncomment and use `ad_url`. You may want to use this if your
 # experiment is served from a subdirectory off of the domain name. Otherwise,
 # leave this as-is.
-;;ad_url = %(ad_url_protocol)s://%(ad_url_host)s:%(ad_url_port)s/%(ad_url_route)s
+;ad_url = %(ad_url_protocol)s://%(ad_url_host)s:%(ad_url_port)s/%(ad_url_route)s
 
 ############################## Database Parameters #############################
 [Database Parameters]
@@ -111,7 +113,7 @@
 ;errorlog = server.log
 # For backwards compatibility, `logfile` is synonymous with `errorlog`. If
 # both are set, `errorlog` will be preferred over `logfile`.
-;;logfile = server.log
+;logfile = server.log
 
 # Log level for the psiturk gunicorn server
 ;loglevel = 2

--- a/psiturk/example/config.txt.sample
+++ b/psiturk/example/config.txt.sample
@@ -50,6 +50,10 @@
 # accepting this HIT
 ;block_quals =
 
+# A path to a custom JSON qualifications file, where you can define your own
+# MTurk qualification requirements, as seen in advanced_quals.json.sample
+;advanced_quals_path = ./advanced_quals.json
+
 ## Hit Configuration - Ad Url ##################################################
 # Config settings for constructing the task's "landing page"
 #

--- a/scripts/create_sample_config_from_defaults.py
+++ b/scripts/create_sample_config_from_defaults.py
@@ -13,7 +13,7 @@ for line in lines:
             f'# Example config file. Uncomment lines (remove the `;`)\n'
             f'# in order to override defaults.\n'
         )
-    if len(line) > 1 and line[0] not in ['#', '[']:  # every line will have at least an \n char
+    if len(line) > 1 and line[0] not in ['#', '[', ';']:  # every line will have at least an \n char
         line = f';{line}'
     new_lines.append(line)
     line_num += 1


### PR DESCRIPTION
Currently, the PsiTurk custom qualification feature only allows for binary has-this-qualification-been-granted support. However, it's not hard at all to abstract the qualification logic to allow for supplying a JSON file of more advanced qualification requirements, which would allow users to provide their own MTurk-formatted qualification tests with performance thresholds directly to the HITs, like seen in [this blog post](https://katherinemwood.github.io/post/qualifications/). 

I've been using this updated version of PsiTurk in all of my recently created HITs and it works wonderfully alongside a script I built to upload custom qualification tests to MTurk and return their ID. I've seen this issue crop up before (https://github.com/NYUCCL/psiTurk/issues/458) and the code is so simple to fix it and saves so much work that I figure a PR would be beneficial for a lot of people. I can also add in format checking to make sure that the advanced_qualifications JSON file has the correct structure, but overall I definitely think this feature could only be a positive addition.
