### PR TITLE
prefer aws creds set via env

### DIFF
--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -268,6 +268,12 @@ class MTurkServices(object):
             kwargs['aws_secret_access_key'] = aws_secret_access_key
 
         self.mtc = boto3.client('mturk', **kwargs)
+
+        # aws access key might have been set via env var -- fetch it and
+        # set it to the psiturk config for dashboard use
+        self.config.set('AWS Access', 'aws_access_key_id',
+                        boto3.DEFAULT_SESSION.get_credentials().access_key)
+
         return True
 
     def verify_aws_login(self):
@@ -325,7 +331,7 @@ class MTurkServices(object):
         for qual_id in hit_config['block_qualification_ids']:
             quals.append(dict(QualificationTypeId=qual_id,
                               Comparator='DoesNotExist'))
-        
+
         for advanced_qual in hit_config['advanced_qualifications']:
             quals.append(dict(advanced_qual))
 

--- a/psiturk/psiturk_config.py
+++ b/psiturk/psiturk_config.py
@@ -71,7 +71,12 @@ class PsiturkConfig(ConfigParser):
                 self.set(bc['in_section'], bc['prefer_this'], os.environ.get(env_key))
 
         # prefer environment
-        these_as_they_are = ['PORT', 'DATABASE_URL']  # heroku sets these
+        these_as_they_are = [
+            'PORT',
+            'DATABASE_URL',
+            'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY'
+            ]  
         for section in self.sections():
             for config_var in self[section]:
                 config_var_upper = config_var.upper()


### PR DESCRIPTION
also, set aws access key id from default session, in the event that it 
wasn't set in psiturk's config files but was set in ones that boto 
prefers