### PR TITLE
Fix friendly dashboard denial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 ### Fixed
 - user_utils.PsiTurkAuthorization should not allow empty username or password! (#492)
+- aws env vars AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are now preferred over anything
+  set in a config file somewhere (#496)
+- Dashboard will refuse to start if `secret_key` is missing or if no valid mturk credentials (#497)
 
 ### Added
 - Add custom MTurk qualification support (#493)

--- a/psiturk/user_utils.py
+++ b/psiturk/user_utils.py
@@ -33,10 +33,11 @@ class PsiTurkAuthorization(object):
     """ Authorize route """
 
     def __init__(self, config):
-        username = config.get('Server Parameters', 'login_username')
-        password = config.get('Server Parameters', 'login_pw')
-        if not username or not password:
-            raise PsiturkException(message='Secure route specified, but login_username or login_pw not set! Set them in config.txt')
+        username   = config.get('Server Parameters', 'login_username')
+        password   = config.get('Server Parameters', 'login_pw')
+        secret_key = config.get('Server Parameters', 'secret_key')
+        if not username or not password or not secret_key:
+            raise PsiturkException(message='Secure route specified, but at least one of `login_username`, `login_pw`, and `secret_key` not set in config! Set them and try again.')
         self.queryname = username
         self.querypw = password
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ def experiment_dir(tmpdir, bork_aws_environ, edit_config_file):
     os.environ['PSITURK_AD_URL_DOMAIN'] = 'example.com'
     os.environ['PSITURK_LOGIN_USERNAME'] = 'foo'
     os.environ['PSITURK_LOGIN_PW'] = 'bar'
+    os.environ['PSITURK_SECRET_KEY'] = 'baz'
 
     # the setup script already chdirs into here,
     # although I don't like that it does that


### PR DESCRIPTION
Dashboard will refuse to start if `secret_key` is missing or if no valid mturk credentials. Fixes obscure error message and fixes infinite redirect loop respectively.