### PR TITLE
Remove getting local HIT id's from Participants table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Added
+- Add custom MTurk qualification support (#493)
+- /dashboard/campaigns and /dashboard/tasks now warn if `do_scheduler` is `False` (#502)
+- amt_services_wrapper's _get_local_hitids no longer queries the Participants table for hitids.
+  Instead, it wholly relies on the Hit table (`amt_hits` by default). (#498) -- Thanks @evankirkles!
+
+  Experiments that are migrating from psiturk v2 should run the new `psiturk migrate db` command
+  when migrating to this release.
+
 ### Fixed
 - user_utils.PsiTurkAuthorization should not allow empty username or password! (#492)
 - aws env vars AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are now preferred over anything
@@ -15,9 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Campaigns' "update goal" functionality fixed -- the associated task is updated with
   the new goal (#502)
 
-### Added
-- Add custom MTurk qualification support (#493)
-- /dashboard/campaigns and /dashboard/tasks now warn if `do_scheduler` is `False` (#502)
 
 ### Changed
 - Migrate from Travis CI to Github Actions (#500)

--- a/psiturk/amt_services_wrapper.py
+++ b/psiturk/amt_services_wrapper.py
@@ -629,11 +629,7 @@ class MTurkServicesWrapper(object):
         return {'hit_tally': num_hits}
 
     def _get_local_hitids(self):
-        participant_hitids = [
-            part.hitid for part in Participant.query.distinct(Participant.hitid)]
-        hit_hitids = [hit.hitid for hit in Hit.query.distinct(Hit.hitid)]
-        my_hitids = list(set(participant_hitids + hit_hitids))
-        return my_hitids
+        return [hit.hitid for hit in Hit.query.distinct(Hit.hitid)]
 
     @amt_services_wrapper_response
     def get_active_hits(self, all_studies=False):
@@ -665,7 +661,7 @@ class MTurkServicesWrapper(object):
 
     def _get_hits(self, all_studies=False):
         # get all hits from amt
-        # then filter to just the ones that have an id that appears in either local Hit or Worker tables
+        # then filter to just the ones that have an id that appears in the local Hit table
         response = self.amt_services.get_all_hits()
         if not response.success:
             raise response.exception

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -10,6 +10,7 @@ except ImportError:
 import urllib3.contrib.pyopenssl
 from psiturk.utils import *
 from psiturk.models import Participant
+from psiturk.db import migrate_db
 from psiturk import experiment_server_controller as control
 from psiturk.psiturk_config import PsiturkConfig
 from psiturk.version import version_number
@@ -1001,6 +1002,23 @@ class PsiturkNetworkShell(Cmd, object):
                 help_struct.keys()), 15, 80)
             self.print_topics(self.super_header, cmds_super, 15, 80)
 
+    @docopt_cmd
+    def do_migrate(self, arg):
+        """
+        Usage:
+          migrate db
+        """
+
+        # Right now, the only thing it does is copies all hitids from
+        # the assignments table into the amt_hits table
+        result = migrate_db()
+        self.poutput(result['message'])
+
+    migrate_commands = ('db')
+
+    def complete_migrate(self, text, line, begidx, endidx):
+        """ Tab-complete migrate command """
+        return [i for i in migrate_commands if i.startswith(text)]
 
 def run(script=None, execute=None, testfile=None, quiet=False):
     try:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,5 @@
+import pytest
+
+def test_migrate_db():
+    from psiturk.db import migrate_db
+    migrate_db()

--- a/tests/test_psiturk_shell.py
+++ b/tests/test_psiturk_shell.py
@@ -129,7 +129,8 @@ commands = [
     (['worker list --hit ABC'], 'worker_list_hitid'),
     (['worker list --approved --hit ABC'], 'worker_list_approved_hitid'),
     (['worker list --submitted --all-studies'], 'worker_list_submitted_allstudies'),
-    (['debug -p'], 'debug_print')
+    (['debug -p'], 'debug_print'),
+    (['migrate db'], 'migrate_db')
 ]
 
 generate_transcripts = False


### PR DESCRIPTION
Speeds up querying local HIT id's vastly, especially on AWS accounts with many participants. For example, my dashboard loaded the local HITs in about 8 seconds before this commit, and in <1 after this commit. 

Doesn't seem like there would ever be a case in which Participants would have a HIT Id not in the HIT Id table anyways, unless you're talking about really old backwards compatibility to before the HIT table would be a thing.