### PR TITLE
Deferred datastring column for insane Participant query speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ thought through.
   in config.txt. See [the configuration overview page in the documentation](https://psiturk.readthedocs.io/en/latest/configuration-overview.html) for more information.
 - changed the default tablename to be `assignments` instead of `turkdemo`
 - changed the `amt_keywords` key to be just `keywords`
-- moved `contact_email_on_error`, `browser_exclude_rule`, and `cutoff_time` under the `Task Parameters` section.
+- moved `contact_email_on_error`, `browser_exclude_rule`, `cutoff_time`, and `allow_repeats` under the `Task Parameters` section.
 - Renamed `launch_in_sandbox` (True, False) to be `launch_in_mode` (Sandbox, Live)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Migrate from Travis CI to Github Actions (#500)
 - API now uses a custom error handler to pass sometimes-gory exception messages back to the api user (#502)
+- Change the Participant.datastring column to be lazy-loaded, causing the datastring to not be loaded by the
+  sqlalchemy model until explicilty requested. Leads to massive speed increases for any query involving the
+  Participant table for cases where the datastring is large. (#504)
 
 ## [3.1.0]
 ### Added

--- a/doc/migrating.rst
+++ b/doc/migrating.rst
@@ -71,13 +71,21 @@ environment variables over psiturk defaults. This enables
 having different config settings locally versus on hosted platforms such as Heorku.
 See the :ref:`configuration-overview` page for more information.
 
-Note that the location of a few config variables has changed:
-* ``contact_email_on_error``, ``browser_exclude_rule``, and ``cutoff_time`` have moved under the ``Task Parameters`` section.
+Note that the location of the following config vars moved to the "Task Parameters" section:
+
+* ``contact_email_on_error``
+* ``browser_exclude_rule``
+* ``cutoff_time``
+* ``allow_repeats``
+
+And a few have been renamed:
+
 * ``amt_keywords`` has been renamed to ``keywords``
-* ``launch_in_sandbox`` has been changed to ``launch_in_mode``.
+* ``launch_in_sandbox`` has been renamed to ``launch_in_mode``.
 
 And a few security-related config values now have *no* default values -- you must set your own
 for certain features to work:
+
 * ``login_username``
 * ``login_pw``
 * ``secret_key``


### PR DESCRIPTION
By deferring the datastring column, we can skip loading in of the trial data JSON cells (which are generally massive), and only query them into a model on their first explicit reference from a Participant object. See [here](https://docs.sqlalchemy.org/en/14/orm/loading_columns.html) for more.

This cut my many-row queries on the Participants table down from 40+ seconds each to literally under 1. yay