### PR TITLE
Update dashboard.txt

### DIFF
--- a/doc/dashboard.rst
+++ b/doc/dashboard.rst
@@ -6,7 +6,7 @@ Dashboard Overview
 
 A dashboard is available at route ``/dashboard``. The dashboard can be enabled
 by setting :ref:`settings-enable-dashboard` to ``True``, and by setting a
-:ref:`settings-login-username` and :ref:`settings-login-pw`.
+:ref:`settings-login-username`, :ref:`settings-login-pw`, and :ref:`settings-secret-key`.
 
 
 


### PR DESCRIPTION
Updating dashboard.txt to instruct users to also set secret_key as a config variable if they want to enable the dashboard. Before this commit, secret_key is not mentioned as a needed variable, leading to a PsiturkException when you enable the dashboard without secret_key.

Please review whether you can reference the secret_key variable through :ref:`settings-secret-key`. I was not sure if this was available as a reference but was following the syntax of :ref:`settings-login-*`