### PR TITLE
Fix SSTI vulnerability in ad and consent pages

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -383,9 +383,10 @@ def advertisement():
         # even have accepted the HIT.
         with open('templates/ad.html', 'r') as temp_file:
             ad_string = temp_file.read()
-        ad_string = insert_mode(ad_string, mode)
+        ad_string = insert_mode(ad_string)
         return render_template_string(
             ad_string,
+            mode=mode,
             hitid=hit_id,
             assignmentid=assignment_id,
             workerid=worker_id
@@ -409,9 +410,10 @@ def give_consent():
     mode = request.args['mode']
     with open('templates/consent.html', 'r') as temp_file:
         consent_string = temp_file.read()
-    consent_string = insert_mode(consent_string, mode)
+    consent_string = insert_mode(consent_string)
     return render_template_string(
         consent_string,
+        mode=mode,
         hitid=hit_id,
         assignmentid=assignment_id,
         workerid=worker_id
@@ -734,7 +736,7 @@ def ppid():
 # to avoid breaking backwards compatibility with old templates.
 
 
-def insert_mode(page_html, mode):
+def insert_mode(page_html):
     """ Insert mode """
     page_html = page_html
     match_found = False
@@ -743,7 +745,7 @@ def insert_mode(page_html, mode):
     for match in matches:
         match_found = True
     if match_found:
-        new_html = page_html[:match.end()] + "&mode=" + mode +\
+        new_html = page_html[:match.end()] + '&mode={{ mode }}' +\
             page_html[match.end():]
         return new_html
     else:

--- a/tests/test_psiturk.py
+++ b/tests/test_psiturk.py
@@ -141,7 +141,7 @@ def test_insert_mode(psiturk_test_client):
         ad_string = temp_file.read()
 
     from psiturk.experiment import insert_mode
-    insert_mode(ad_string, 'debug')
+    insert_mode(ad_string)
 
 
 class PsiTurkStandardTests(PsiturkUnitTest):


### PR DESCRIPTION
Fixed an issue where users could pass arbitrary Python code to be executed on the server to the mode HTTP arg

More information about this type of vulnerability: https://secure-cookie.io/attacks/ssti/