### PR TITLE
Make assignment of table name consistent with instructions in config

### DIFF
--- a/psiturk/models.py
+++ b/psiturk/models.py
@@ -19,7 +19,8 @@ config.load_config()
 
 # The "table_name" config key is deprecated -- it will be replaced by
 # `assignments_table_name` in a future release.
-ASSIGNMENTS_TABLENAME = config.get('Database Parameters', 'table_name')
+ASSIGNMENTS_TABLENAME = config.get('Database Parameters', 'assignments_table_name') or \
+                        config.get('Database Parameters', 'table_name')
 HITS_TABLENAME = config.get('Database Parameters', 'hits_table_name')
 CAMPAIGNS_TABLENAME = config.get('Database Parameters', 'campaigns_table_name')
 


### PR DESCRIPTION
… config file

In `psiturk/default_configs/local_config_defaults.txt` it says that `table_name` is deprecated and to use `assignments_table_name` instead. It also says that if
both are set, `assignments_table_name` will be preferred over `table_name`.

This code should satisfy that contract.