### PR TITLE
Fix two backwards compatibility bugs

### DIFF
--- a/psiturk/psiturk_config.py
+++ b/psiturk/psiturk_config.py
@@ -96,13 +96,18 @@ class PsiturkConfig(ConfigParser):
                 'prefer_this': 'advanced_quals_path',
                 'over_this': 'advanced_quals_path_sandbox'
             },
+            {
+                'in_section': 'Database Parameters',
+                'prefer_this': 'assignments_table_name',
+                'over_this': 'table_name'
+            }
         ]
         for bc in backwards_compatibilities:
             env_key = f'PSITURK_{bc["prefer_this"].upper()}'
             if env_key in os.environ:
                 self.set(bc['in_section'], bc['over_this'], os.environ.get(env_key))
             else:
-                preferred = self.get('HIT Configuration', bc['prefer_this'], fallback=None)
+                preferred = self.get(bc['in_section'], bc['prefer_this'], fallback=None)
                 if preferred:
                     self.set(bc['in_section'], bc['over_this'], preferred)
 


### PR DESCRIPTION
1. The local config file text says that `table_name` is being deprecated in favor of `assignments_table_name` and that `assignments_table_name` is preferred if both defined. However, only `table_name` was being used. An entry into the backwards_compatibility list in psiturk_config.py was added for this.
2. In the psiturk_config.py loop through the backwards compatibilities, the section was being hard-coded to `Hit Configuration`. This prevented fix in (1) from taking effect. It also was preventing the backwards compatibility setting for the logfiles from taking effect.