### PR TITLE
Adds bonus history functionality to wrapper, increases page size

### DIFF
--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -189,7 +189,8 @@ class MTurkServices(object):
         for hit_id in hit_ids:
             paginator = self.mtc.get_paginator('list_assignments_for_hit')
             args = dict(
-                HITId=hit_id
+                HITId=hit_id,
+                PaginationConfig={'PageSize':100}
             )
             if assignment_status:
                 args['AssignmentStatuses'] = [assignment_status]
@@ -228,7 +229,8 @@ class MTurkServices(object):
         if hit_id:
             paginator = self.mtc.get_paginator('list_bonus_payments')
             args = dict(
-                HITId=hit_id
+                HITId=hit_id,
+                PaginationConfig={'PageSize':100}
             )
             for page in paginator.paginate(**args):
                 bonuses.extend(page['BonusPayments'])
@@ -239,6 +241,7 @@ class MTurkServices(object):
                 paginator = self.mtc.get_paginator('list_bonus_payments')
                 args = dict(
                     AssignmentId=assignment_id,
+                    PaginationConfig={'PageSize':100}
                 )
                 for page in paginator.paginate(**args):
                     bonuses.extend(page['BonusPayments'])
@@ -417,7 +420,8 @@ class MTurkServices(object):
         qualification_types = []
         kwargs = {
             'MustBeRequestable': MustBeRequestable,
-            'MustBeOwnedByCaller': MustBeOwnedByCaller
+            'MustBeOwnedByCaller': MustBeOwnedByCaller,
+            'PaginationConfig': {'PageSize':100}
         }
         if Query:
             kwargs['Query'] = Query

--- a/psiturk/amt_services.py
+++ b/psiturk/amt_services.py
@@ -220,6 +220,36 @@ class MTurkServices(object):
             'status': assignment['AssignmentStatus'],
         }
         return worker_data
+    
+    @amt_service_response
+    def get_bonuses(self, hit_id=None, assignment_ids=None):
+        """Get a list of paid bonuses."""
+        bonuses = []
+        if hit_id:
+            paginator = self.mtc.get_paginator('list_bonus_payments')
+            args = dict(
+                HITId=hit_id
+            )
+            for page in paginator.paginate(**args):
+                bonuses.extend(page['BonusPayments'])
+        elif assignment_ids:
+            if not isinstance(assignment_ids, list):
+                assignment_ids = [assignment_ids]
+            for assignment_id in assignment_ids:
+                paginator = self.mtc.get_paginator('list_bonus_payments')
+                args = dict(
+                    AssignmentId=assignment_id,
+                )
+                for page in paginator.paginate(**args):
+                    bonuses.extend(page['BonusPayments'])
+        bonus_data = [{
+            'workerId': bonus['WorkerId'],
+            'bonusAmount': bonus['BonusAmount'],
+            'assignmentId': bonus['AssignmentId'],
+            'reason': bonus['Reason'],
+            'grantTime': bonus['GrantTime']
+        } for bonus in bonuses]
+        return bonus_data
 
     @amt_service_response
     def bonus_assignment(self, assignment_id, worker_id, amount, reason=""):

--- a/psiturk/api/__init__.py
+++ b/psiturk/api/__init__.py
@@ -278,6 +278,15 @@ class TaskList(Resource):
         raise APIException(message='task name `{}` not recognized!'.format(data['name']))
 
 
+class BonusList(Resource):
+    def post(self):
+        data = request.json
+        hit_id = data['hit_id'] if 'hit_id' in data else None
+        assignment_ids = data['assignment_ids'] if 'assignment_ids' in data else None
+        bonuses = services_manager.amt_services_wrapper.get_bonuses(
+            hit_id=hit_id, assignment_ids=assignment_ids).data
+        return bonuses, 201
+
 api.add_resource(ServicesManager, '/services_manager', '/services_manager/')
 
 api.add_resource(AssignmentList, '/assignments', '/assignments/')
@@ -292,5 +301,7 @@ api.add_resource(Campaigns, '/campaigns/<campaign_id>')
 
 api.add_resource(TaskList, '/tasks', '/tasks/')
 api.add_resource(Tasks, '/tasks/<task_id>')
+
+api.add_resource(BonusList, '/bonuses', '/bonuses/')
 
 api.init_app(api_blueprint)


### PR DESCRIPTION
The MTurk boto3 client has functionality for getting a list of all paid bonuses for a specified HIT or for a specified assignment id. I've implemented this over on my own dashboard and it's been really useful to our lab with keeping payments clear regarding who we've paid per hit, and how much––especially for experiments not run through PsiTurk. I assume it can't hurt to have the master amt_services_wrapper also have this functionality if someone wants to work with this in the future.

I also bumped up the page size so we don't need as many pagination requests to AWS.