### PR TITLE
bump pyopenssl to 22.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
   GitPython~=3.1.0
   python-dotenv~=0.12.0
   python_dateutil~=2.8.1
-  pyOpenSSL~=19.0.0
+  pyOpenSSL~=22.0.0
   setproctitle~=1.1.10
 packages=
   psiturk


### PR DESCRIPTION
closes #550 