### PR TITLE
test_spockturk_shell: running cmds so responses can be captured

### DIFF
--- a/tests/test_psiturk_shell.py
+++ b/tests/test_psiturk_shell.py
@@ -161,6 +161,8 @@ def test_do_commands(get_shell, pytestconfig, cmds, name, stubber, capsys):
     else:
         # if name == 'worker_approve_all':
         # pytest.set_trace()
+        for cmd in cmds:
+            shell.runcmds_plus_hooks(cmd)
         response = shell.runcmds_plus_hooks(cmds)
         captured = capsys.readouterr()
         # with capsys.disabled():


### PR DESCRIPTION
fixes #473 

There were no shell commands being run that the tests could get response or catch errors. I couldn't add ``shell.runcmds_plus_hooks(cmds)`` because the function expects a string instead of a list of strings (very confused by this). 

I was using ``print(f"\ncaptured.err: {captured.err}\ncaptured: {captured}")`` right before assertion to verify the shell commands were being run. 