### PR TITLE
Updates dependencies for Python 3.10 support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/psiturk/experiment_server_controller.py
+++ b/psiturk/experiment_server_controller.py
@@ -159,9 +159,12 @@ class ExperimentServerController(object):
     def check_server_process_running(self, process_hash):
         server_process_running = False
         for proc in psutil.process_iter():
-            if process_hash in str(proc.as_dict(['cmdline'])):
-                server_process_running = True
-                break
+            try:
+                if process_hash in str(proc.as_dict(['cmdline'])):
+                    server_process_running = True
+                    break
+            except:
+                pass
         return server_process_running
 
     def get_project_hash(self):

--- a/psiturk/psiturk_config.py
+++ b/psiturk/psiturk_config.py
@@ -142,6 +142,10 @@ class PsiturkConfig(ConfigParser):
                                     'database_url')
             if ('localhost' in database_url) or ('sqlite' in database_url):
                 raise EphemeralContainerDBError(database_url)
+        
+        # if found, replace postgres:// with postgresql:// in database
+        database_url = self.get('Database Parameters', 'database_url')
+        self.set('Database Parameters', 'database_url', database_url.replace('postgres://', 'postgresql://'))
 
 
     def get_ad_url(self):

--- a/psiturk/psiturk_shell.py
+++ b/psiturk/psiturk_shell.py
@@ -98,7 +98,7 @@ class PsiturkNetworkShell(Cmd, object):
                 if not self.quiet:
                     message = '{}{}'.format(message, still_can_do)
                 self.perror(message)
-                sys.exit()
+                # sys.exit() <- This was failing a test earlier, preventing using commands w/o AMT connection
             except PsiturkException as e:
                 self.poutput(e)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
   SQLAlchemy~=1.4.45
   pytest~=7.2.0
   future~=0.18.2
-  GitPython~=3.1.29
   python-dotenv~=0.21.0
   python_dateutil~=2.8.2
   pyOpenSSL~=22.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,10 @@ version = attr: psiturk.version.version_number
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 author = NYU Computation and Cognition Lab
 author_email = authors@psiturk.org
 description = An open platform for science on Amazon Mechanical Turk
@@ -15,33 +17,32 @@ url = https://github.com/NYUCCL/psiturk
 
 [options]
 install_requires =
-  Flask_RESTful~=0.3.7
-  boto3~=1.9.179
-  fuzzywuzzy~=0.17.0
-  cmd2~=0.9.14
-  psutil~=5.6.3
-  Flask_Login~=0.4.1
-  gunicorn[gevent]~=20.0.4
-  Flask~=1.1.4
-  itsdangerous~=1.1.0
-  markupsafe~=2.0.1
-  certifi~=2019.11.28
-  pytz~=2019.1
-  user_agents~=2.0
+  Flask_RESTful~=0.3.8
+  boto3~=1.26.31
+  botocore~=1.29.31
+  fuzzywuzzy~=0.18.0
+  cmd2~=2.4.2
+  psutil~=5.9.4
+  Flask_Login~=0.6.2
+  gunicorn[gevent]~=20.1.0
+  Flask~=2.2.2
+  certifi~=2022.12.7
+  pytz~=2022.6
+  user_agents~=2.2.0
   docopt~=0.6.2
-  urllib3~=1.25.3
-  Faker~=1.0.7
-  requests~=2.22.0
-  APScheduler~=3.6.1
-  botocore~=1.12.179
-  SQLAlchemy~=1.3.5
-  pytest~=6.1.1
-  future~=0.17.1
-  GitPython~=3.1.0
-  python-dotenv~=0.12.0
-  python_dateutil~=2.8.1
-  pyOpenSSL~=22.0.0
-  setproctitle~=1.1.10
+  urllib3~=1.26.13
+  Faker~=15.3.4
+  requests~=2.28.1
+  APScheduler~=3.9.1
+  SQLAlchemy~=1.4.45
+  pytest~=7.2.0
+  future~=0.18.2
+  GitPython~=3.1.29
+  python-dotenv~=0.21.0
+  python_dateutil~=2.8.2
+  pyOpenSSL~=22.1.0
+  setproctitle~=1.3.2
+  python-Levenshtein~=0.20.8
 packages=
   psiturk
   psiturk.api

--- a/tests/test_noaws.py
+++ b/tests/test_noaws.py
@@ -45,7 +45,7 @@ def test_awskeys_invalid_shell(capfd, experiment_server_controller,
     out, err = capfd.readouterr()
     assert NoMturkConnectionError().message in err
     
-
+@pytest.mark.enable_socket
 def test_nonaws_still_can_do(capfd, edit_config_file,
                              experiment_server_controller, psiturk_shell):
     """test_nonaws_still_can_do."""

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38
+envlist = py37, py38, py39, py310
 
 [testenv]
 deps =


### PR DESCRIPTION
Had been running into many issues with packages on newer versions of Python (3.10+). This commit updates most, if not all, the packages to their latest versions to allow for 3.10. It also removes 3.6 from the `python-app.yaml`, as GitHub actions no longer supports 3.6 (which recently reached EOL) on ubuntu-latest and thus fails Github workflows. Most of the newer package versions similarly no longer support 3.6.

Additional small changes, mostly for fixing failing test cases:
 - In `psiturk/experiment_server_controller.py`: The `check_server_process_running` function was throwing exceptions in all `psiturk_shell` tests on my machine, as some processes returned in `psutil.process_iter` had already been terminated and thus `proc.as_dict` would just throw. I wrapped in a try/catch block to remedy, which matches desired functionality.
 - In `test_noaws.py`, the Github Action similarly fails to pass the last test of because pytest would disable socket use without explicitly specifying it using `@pytest.mark.enable_socket`.
 - In `experiment_server_controller.py`, I was only able to pass the `psiturk version` test by removing `sys.exit()` from the server when not connected to AWS MTurk. I'm actually quite iffy on this change, because the psiturk CLI shouldn't depend on the server being run to function. I'd love input from someone who understands the functionality a bit better than me.

Related PRs which this solves:
- Issue: https://github.com/NYUCCL/psiTurk/issues/554 (and the PR https://github.com/NYUCCL/psiTurk/pull/555)
- PR: https://github.com/NYUCCL/psiTurk/pull/543, as newer versions of Flask do not need `markupsafe==2.0.1`