### PR TITLE
use with_entities to pull only cond and counterbalance

### DIFF
--- a/psiturk/experiment.py
+++ b/psiturk/experiment.py
@@ -206,7 +206,7 @@ def get_random_condcount(mode):
                    Participant.status == CREDITED,
                    Participant.status == SUBMITTED,
                    Participant.status == BONUSED,
-                   Participant.beginhit > starttime)).all()
+                   Participant.beginhit > starttime)).with_entities(Participant.cond, Participant.counterbalance).all()
     counts = Counter()
     for cond in range(numconds):
         for counter in range(numcounts):


### PR DESCRIPTION
surprised no one has run into this issue before - my task app was using ridiculous amounts of memory from querying participants just to assign cond/counterbalance

I guess others probably save smaller/simpler/more efficiently coded datastrings or collect data from fewer participants for each codeversion

using .with_entities to just grab the cond and counterbalance columns seems more efficient